### PR TITLE
Readme: Fix build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ $ cargo install cargo-xbuild
 Afterwards, the loader can be build as follows:
 
 ```bash
-$ cargo xbuild --target x86_64-unknown-hermit-loader.json
+$ make
 ```
 
 Afterwards, the loader is stored in `target/x86_64-unknown-hermit-loader/debug/` as `rusty-loader`.


### PR DESCRIPTION
Make should be used to build the loader. Otherwise Qemu will fail to load the loader.

Related to: https://github.com/hermitcore/libhermit-rs/pull/28