### PR TITLE
Refactor: Use Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.5"
 authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>", "Colin Finck <colin.finck@rwth-aachen.de>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 bitflags = "1.2.*"

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 #[cfg(target_arch = "x86_64")]
-pub use arch::x86_64::*;
+pub use crate::arch::x86_64::*;
 
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;

--- a/src/arch/x86_64/bootinfo.rs
+++ b/src/arch/x86_64/bootinfo.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::x86_64::SERIAL_PORT_ADDRESS;
+use crate::arch::x86_64::SERIAL_PORT_ADDRESS;
 use core::fmt;
 
 #[repr(C)]

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -11,12 +11,12 @@ pub mod processor;
 pub mod serial;
 
 pub use self::bootinfo::*;
-use arch::x86_64::paging::{BasePageSize, LargePageSize, PageSize, PageTableEntryFlags};
-use arch::x86_64::serial::SerialPort;
+use crate::arch::x86_64::paging::{BasePageSize, LargePageSize, PageSize, PageTableEntryFlags};
+use crate::arch::x86_64::serial::SerialPort;
+use crate::elf::ELF_EM_X86_64;
+use crate::physicalmem;
 use core::{mem, slice};
-use elf::*;
 use multiboot::Multiboot;
-use physicalmem;
 
 extern "C" {
 	static mb_info: usize;

--- a/src/arch/x86_64/paging.rs
+++ b/src/arch/x86_64/paging.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::physicalmem;
 use core::marker::PhantomData;
-use physicalmem;
 
 /// Pointer to the root page table (PML4)
 const PML4_ADDRESS: *mut PageTable<PML4> = 0xFFFF_FFFF_FFFF_F000 as *mut PageTable<PML4>;
@@ -88,15 +88,17 @@ impl PageTableEntry {
 		if flags.contains(PageTableEntryFlags::HUGE_PAGE) {
 			// HUGE_PAGE may indicate a 2 MiB or 1 GiB page.
 			// We don't know this here, so we can only verify that at least the offset bits for a 2 MiB page are zero.
-			assert!(
-				physical_address % LargePageSize::SIZE == 0,
+			assert_eq!(
+				physical_address % LargePageSize::SIZE,
+				0,
 				"Physical address is not on a 2 MiB page boundary (physical_address = {:#X})",
 				physical_address
 			);
 		} else {
 			// Verify that the offset bits for a 4 KiB page are zero.
-			assert!(
-				physical_address % BasePageSize::SIZE == 0,
+			assert_eq!(
+				physical_address % BasePageSize::SIZE,
+				0,
 				"Physical address is not on a 4 KiB page boundary (physical_address = {:#X})",
 				physical_address
 			);

--- a/src/console.rs
+++ b/src/console.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch;
+use crate::arch;
 use core::fmt;
 
 pub struct Console;
@@ -19,6 +19,7 @@ impl fmt::Write for Console {
 		Ok(())
 	}
 
+	//ToDo: Does this work for arbitrary utf8 strings?
 	/// Print a string of characters.
 	fn write_str(&mut self, s: &str) -> fmt::Result {
 		for character in s.chars() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,15 +15,8 @@
 #![feature(core_intrinsics)]
 #![no_std]
 
-// EXTERNAL CRATES
 #[macro_use]
 extern crate bitflags;
-
-#[cfg(target_arch = "x86_64")]
-extern crate multiboot;
-
-#[cfg(target_arch = "x86_64")]
-extern crate x86;
 
 // MODULES
 #[macro_use]
@@ -38,7 +31,7 @@ mod runtime_glue;
 
 // IMPORTS
 use arch::paging::{BasePageSize, LargePageSize, PageSize};
-use arch::BOOT_INFO;
+use arch::x86_64::BOOT_INFO;
 use core::ptr;
 use elf::*;
 
@@ -60,12 +53,12 @@ pub unsafe fn sections_init() {
 pub unsafe fn check_kernel_elf_file(start_address: usize) -> (usize, usize, usize, usize, usize) {
 	// Verify that this module is a HermitCore ELF executable.
 	let header = &*(start_address as *const ElfHeader);
-	assert!(header.ident.magic == ELF_MAGIC);
-	assert!(header.ident._class == ELF_CLASS_64);
-	assert!(header.ident.data == ELF_DATA_2LSB);
-	assert!(header.ident.pad[0] == ELF_PAD_HERMIT);
-	assert!(header.ty == ELF_ET_EXEC);
-	assert!(header.machine == arch::ELF_ARCH);
+	assert_eq!(header.ident.magic, ELF_MAGIC);
+	assert_eq!(header.ident._class, ELF_CLASS_64);
+	assert_eq!(header.ident.data, ELF_DATA_2LSB);
+	assert_eq!(header.ident.pad[0], ELF_PAD_HERMIT);
+	assert_eq!(header.ty, ELF_ET_EXEC);
+	assert_eq!(header.machine, crate::arch::x86_64::ELF_ARCH);
 	loaderlog!("This is a supported HermitCore Application");
 
 	// Get all necessary information about the ELF executable.
@@ -103,8 +96,8 @@ pub unsafe fn check_kernel_elf_file(start_address: usize) -> (usize, usize, usiz
 	}
 
 	// Verify the information.
-	assert!(physical_address % BasePageSize::SIZE == 0);
-	assert!(virtual_address % LargePageSize::SIZE == 0);
+	assert_eq!(physical_address % BasePageSize::SIZE, 0);
+	assert_eq!(virtual_address % LargePageSize::SIZE, 0);
 	assert!(file_size > 0);
 	assert!(mem_size > 0);
 	loaderlog!("File Size: {} Bytes", file_size);

--- a/src/physicalmem.rs
+++ b/src/physicalmem.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arch::paging::{BasePageSize, PageSize};
+use crate::arch::x86_64::paging::{BasePageSize, PageSize};
 
 static mut CURRENT_ADDRESS: usize = 0;
 
@@ -17,8 +17,9 @@ pub fn init(address: usize) {
 
 pub fn allocate(size: usize) -> usize {
 	assert!(size > 0);
-	assert!(
-		size % BasePageSize::SIZE == 0,
+	assert_eq!(
+		size % BasePageSize::SIZE,
+		0,
 		"Size {:#X} is a multiple of {:#X}",
 		size,
 		BasePageSize::SIZE

--- a/src/runtime_glue.rs
+++ b/src/runtime_glue.rs
@@ -8,7 +8,7 @@
 //! Minor functions that Rust really expects to be defined by the compiler,
 //! but which we need to provide manually because we're on bare metal.
 
-use arch;
+use crate::arch;
 use core::panic::PanicInfo;
 
 #[panic_handler]


### PR DESCRIPTION
- Refactored so that it compiles with `edition = "2018"`
- Additionally changed assert!(x==y) to assert_eq!(x,y)
- Added a ToDo regarding printing of strings to console 
- Tested on Windows if it can rusty-demo