### PR TITLE
Cleanup

### DIFF
--- a/src/arch/x86_64/paging.rs
+++ b/src/arch/x86_64/paging.rs
@@ -5,8 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::physicalmem;
 use core::marker::PhantomData;
+
+use crate::physicalmem;
 
 /// Pointer to the root page table (PML4)
 const PML4_ADDRESS: *mut PageTable<PML4> = 0xFFFF_FFFF_FFFF_F000 as *mut PageTable<PML4>;
@@ -88,15 +89,17 @@ impl PageTableEntry {
 		if flags.contains(PageTableEntryFlags::HUGE_PAGE) {
 			// HUGE_PAGE may indicate a 2 MiB or 1 GiB page.
 			// We don't know this here, so we can only verify that at least the offset bits for a 2 MiB page are zero.
-			assert!(
-				physical_address % LargePageSize::SIZE == 0,
+			assert_eq!(
+				physical_address % LargePageSize::SIZE,
+				0,
 				"Physical address is not on a 2 MiB page boundary (physical_address = 0x{:x})",
 				physical_address
 			);
 		} else {
 			// Verify that the offset bits for a 4 KiB page are zero.
-			assert!(
-				physical_address % BasePageSize::SIZE == 0,
+			assert_eq!(
+				physical_address % BasePageSize::SIZE,
+				0,
 				"Physical address is not on a 4 KiB page boundary (physical_address = 0x{:x})",
 				physical_address
 			);
@@ -312,7 +315,7 @@ impl<L: PageTableLevel> PageTableMethods for PageTable<L> {
 		physical_address: usize,
 		flags: PageTableEntryFlags,
 	) -> bool {
-		assert!(L::LEVEL == S::MAP_LEVEL);
+		assert_eq!(L::LEVEL, S::MAP_LEVEL);
 		let index = page.table_index::<L>();
 		let flush = self.entries[index].is_present();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,12 +18,18 @@
 // EXTERNAL CRATES
 #[macro_use]
 extern crate bitflags;
-
 #[cfg(target_arch = "x86_64")]
 extern crate multiboot;
-
 #[cfg(target_arch = "x86_64")]
 extern crate x86;
+
+use core::intrinsics::{copy_nonoverlapping, write_bytes};
+use core::ptr;
+
+use crate::arch::{map_memory, BOOT_INFO, ELF_ARCH};
+// IMPORTS
+use crate::arch::paging::{BasePageSize, LargePageSize, PageSize};
+use crate::elf::*;
 
 // MODULES
 #[macro_use]
@@ -35,13 +41,6 @@ mod elf;
 mod physicalmem;
 mod rlib;
 mod runtime_glue;
-
-// IMPORTS
-use crate::arch::paging::{BasePageSize, LargePageSize, PageSize};
-use crate::arch::{map_memory, BOOT_INFO, ELF_ARCH};
-use crate::elf::*;
-use core::intrinsics::{copy_nonoverlapping, write_bytes};
-use core::ptr;
 
 extern "C" {
 	static bss_end: u8;
@@ -144,8 +143,8 @@ pub unsafe fn check_kernel_elf_file(start_address: usize) -> (usize, usize, usiz
 	}
 
 	// Verify the information.
-	assert!(physical_address % BasePageSize::SIZE == 0);
-	assert!(virtual_address % LargePageSize::SIZE == 0);
+	assert_eq!(physical_address % BasePageSize::SIZE, 0);
+	assert_eq!(virtual_address % LargePageSize::SIZE, 0);
 	assert!(file_size > 0);
 	assert!(mem_size > 0);
 	loaderlog!("File Size: {} Bytes", file_size);

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,5 +43,5 @@ pub unsafe extern "C" fn loader_main() -> ! {
 		mem_size,
 	);
 
-	arch::boot_kernel(virtual_address, mem_size, entry_point);
+	arch::boot_kernel(virtual_address, mem_size, entry_point)
 }

--- a/src/physicalmem.rs
+++ b/src/physicalmem.rs
@@ -17,8 +17,9 @@ pub fn init(address: usize) {
 
 pub fn allocate(size: usize) -> usize {
 	assert!(size > 0);
-	assert!(
-		size % BasePageSize::SIZE == 0,
+	assert_eq!(
+		size % BasePageSize::SIZE,
+		0,
 		"Size 0x{:x} is a multiple of 0x{:x}",
 		size,
 		BasePageSize::SIZE

--- a/src/rlib.rs
+++ b/src/rlib.rs
@@ -130,7 +130,7 @@ mod test {
 	fn memcpy_and_memcmp_arrays() {
 		let (src, mut dst) = ([b'X'; 100], [b'Y'; 100]);
 		unsafe {
-			assert!(memcmp(src.as_ptr(), dst.as_ptr(), 100) != 0);
+			assert_ne!(memcmp(src.as_ptr(), dst.as_ptr(), 100), 0);
 			let _ = memcpy(dst.as_mut_ptr(), src.as_ptr(), 100);
 			assert_eq!(memcmp(src.as_ptr(), dst.as_ptr(), 100), 0);
 		}


### PR DESCRIPTION
optimizes imports, replaces assert with assert_eq and fixes a linter warning