### PR TITLE
Fix loader. Previously strongly dependent on the input ELF's layout.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@
 
 extern crate rusty_loader;
 
-use core::intrinsics::copy_nonoverlapping;
+use core::intrinsics::copy;
 use rusty_loader::arch;
 use rusty_loader::*;
 
@@ -37,7 +37,8 @@ pub unsafe extern "C" fn loader_main() -> ! {
 		kernel_location,
 		virtual_address
 	);
-	copy_nonoverlapping(
+	arch::map_memory(virtual_address, mem_size);
+	copy(
 		kernel_location as *const u8,
 		virtual_address as *mut u8,
 		mem_size,


### PR DESCRIPTION
So I just found a fun bug while compiling C code for RustyHermit. On booting, the Loader would boot-loop right after `Move kernel from..`. It turns out that the current implementation is fairly broken and all stars have to align for it to work:

- It already has the ELF file in writable memory, then figures out where the kernel is located.
- It then figures out where it should be loaded to, and simply copies it there with a `copy_nonoverlapping()`.

This has two large problems:
1. It is not guaranteed that the memory won't overlap. Depending on the layout of the ELF this might well be the case.
2. Even if it does not overlap, there has to be writable memory at the target location. This is only the case if it is still inside the ELF (?).

Normal Rust applications have enough "junk" in the output that this is likely to be the case so it worked fine there.

My fix is simple:
- use `copy` instead of `copy_nonoverlapping`
- map the memory as writable with the provided `map_memory()` function.

I have not investigated further if this is a good solution, but it works. Does the memory stay writable after the kernel boots? For security reasons we should probably avoid RWX memory.