### PR TITLE
switch to the latest nightly compiler

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,6 @@
 [unstable]
 build-std = ["core", "alloc"]
-build-std-features = ["compiler-builtins-mem", "compiler-builtins-asm"]
+build-std-features = ["compiler-builtins-mem"]
 
 [target.x86_64-unknown-hermit-loader]
 rustflags = [

--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,5 @@ docs:
 
 loader:
 	@echo Build loader
-	cargo build $(opt) -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem,compiler-builtins-asm --target $(target)-loader.json
+	cargo build $(opt) -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target $(target)-loader.json
 	$(CONVERT)

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2020-12-23"
+channel = "nightly-2021-01-22"
 components = [ "rustfmt", "rust-src", "llvm-tools-preview"]

--- a/src/arch/x86_64/serial.rs
+++ b/src/arch/x86_64/serial.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use core::sync::atomic::spin_loop_hint;
+use core::hint::spin_loop;
 use x86::io::*;
 
 const UART_TX: u16 = 0;
@@ -47,7 +47,7 @@ impl SerialPort {
 
 	fn write_to_register(&self, register: u16, byte: u8) {
 		while self.is_transmitting() {
-			spin_loop_hint();
+			spin_loop();
 		}
 
 		unsafe {


### PR DESCRIPTION
- activation of optimized core functions (e.g. memcpy) isn't longer required