### PR TITLE
Fix loader for Qemu Raspi3 target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 edition = "2018"
 
+[features]
+aarch64-qemu-stdout = []    # Output to special qemu address 0x3F20_1000 instead of trying to use uart
+
 [dependencies]
 bitflags = "1.2.*"
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ opt := --release
 rdir := release
 endif
 
+# Todo - make this feature toggleable
+ifeq ($(arch), aarch64)
+opt += --features "aarch64-qemu-stdout"
+endif
+
 CONVERT :=
 RN :=
 ifdef COMSPEC

--- a/src/arch/aarch64/entry.rs
+++ b/src/arch/aarch64/entry.rs
@@ -164,31 +164,42 @@ unsafe fn pre_init() -> ! {
 
 	/*
 	* Prepare system control register (SCTRL)
-	*
-	*
-	*   UCI     [26] Enables EL0 access in AArch64 for DC CVAU, DC CIVAC,
-					 DC CVAC and IC IVAU instructions
-	*   EE      [25] Explicit data accesses at EL1 and Stage 1 translation
-					 table walks at EL1 & EL0 are little-endian
-	*   EOE     [24] Explicit data accesses at EL0 are little-endian
-	*   WXN     [19] Regions with write permission are not forced to XN
-	*   nTWE    [18] WFE instructions are executed as normal
-	*   nTWI    [16] WFI instructions are executed as normal
-	*   UCT     [15] Enables EL0 access in AArch64 to the CTR_EL0 register
-	*   DZE     [14] Execution of the DC ZVA instruction is allowed at EL0
-	*   I       [12] Instruction caches enabled at EL0 and EL1
-	*   UMA     [9]  Disable access to the interrupt masks from EL0
-	*   SED     [8]  The SETEND instruction is available
-	*   ITD     [7]  The IT instruction functionality is available
-	*   THEE    [6]  ThumbEE is disabled
-	*   CP15BEN [5]  CP15 barrier operations disabled
-	*   SA0     [4]  Stack Alignment check for EL0 enabled
-	*   SA      [3]  Stack Alignment check enabled
-	*   C       [2]  Data and unified enabled
-	*   A       [1]  Alignment fault checking disabled
-	*   M       [0]  MMU enable
+	* Todo: - Verify if all of these bits actually should be explicitly set
+			- Link origin of this documentation and check to which instruction set versions
+			  it applies (if applicable)
+			- Fill in the missing Documentation for some of the bits and verify if we care about them
+			  or if loading ond not setting them would be the appropriate action.
 	*/
-	let sctrl_el1: u32 = 0b0100_1101_0101_1101_1001_0001_1100;
+	let sctrl_el1: u64 = 0
+		| (1 << 26) 	/* UCI     	Enables EL0 access in AArch64 for DC CVAU, DC CIVAC,
+					 				DC CVAC and IC IVAU instructions */
+		| (0 << 25)		/* EE      	Explicit data accesses at EL1 and Stage 1 translation
+					 				table walks at EL1 & EL0 are little-endian*/
+		| (0 << 24)		/* EOE     	Explicit data accesses at EL0 are little-endian*/
+		| (1 << 23)
+		| (1 << 22)
+		| (1 << 20)
+		| (0 << 19)		/* WXN     	Regions with write permission are not forced to XN */
+		| (1 << 18)		/* nTWE     WFE instructions are executed as normal*/
+		| (0 << 17)
+		| (1 << 16)		/* nTWI    	WFI instructions are executed as normal*/
+		| (1 << 15)		/* UCT     	Enables EL0 access in AArch64 to the CTR_EL0 register*/
+		| (1 << 14)		/* DZE     	Execution of the DC ZVA instruction is allowed at EL0*/
+		| (0 << 13)
+		| (1 << 12)		/* I       	Instruction caches enabled at EL0 and EL1*/
+		| (1 << 11)
+		| (0 << 10)
+		| (0 << 9)		/* UMA      Disable access to the interrupt masks from EL0*/
+		| (1 << 8)		/* SED      The SETEND instruction is available*/
+		| (0 << 7)		/* ITD      The IT instruction functionality is available*/
+		| (0 << 6)		/* THEE    	ThumbEE is disabled*/
+		| (0 << 5)		/* CP15BEN  CP15 barrier operations disabled*/
+		| (1 << 4)		/* SA0     	Stack Alignment check for EL0 enabled*/
+		| (1 << 3)		/* SA      	Stack Alignment check enabled*/
+		| (1 << 2)		/* C       	Data and unified enabled*/
+		| (0 << 1)		/* A       	Alignment fault checking disabled*/
+		| (0 << 0)		/* M       	MMU enable*/
+		;
 	asm!("msr sctlr_el1, {0}", in(reg) sctrl_el1, options(nostack));
 
 	// Enter loader

--- a/src/arch/aarch64/entry.rs
+++ b/src/arch/aarch64/entry.rs
@@ -12,7 +12,7 @@ extern "C" {
 }
 
 const BOOT_STACK_SIZE: usize = 4096;
-const BOOT_CORE_ID: u64 = 0;	// ID of CPU for booting on SMP systems - this might be board specific in the future
+const BOOT_CORE_ID: u64 = 0; // ID of CPU for booting on SMP systems - this might be board specific in the future
 
 #[link_section = ".data"]
 static STACK: [u8; BOOT_STACK_SIZE] = [0; BOOT_STACK_SIZE];
@@ -76,10 +76,10 @@ unsafe fn pre_init() -> ! {
 
 	/* reset thread id registers */
 	asm!("msr tpidr_el0, {0}",
-        "msr tpidr_el1, {0}",
+		"msr tpidr_el1, {0}",
 		in(reg) 0_u64,
 		options(nostack),
-    );
+	);
 
 	/*
 	 * Disable the MMU. We may have entered the kernel with it on and
@@ -89,21 +89,17 @@ unsafe fn pre_init() -> ! {
 	 * would have also failed.
 	 */
 	asm!("dsb sy",
-        "mrs x2, sctlr_el1",
-        "bic x2, x2, {one}",
-        "msr sctlr_el1, x2",
-        "isb",
+		"mrs x2, sctlr_el1",
+		"bic x2, x2, {one}",
+		"msr sctlr_el1, x2",
+		"isb",
 		one = const 0x1,
 		out("x2") _,
 		options(nostack),
 		//::: "x2" : "volatile"
 	);
 
-	asm!("ic iallu",
-        "tlbi vmalle1is",
-        "dsb ish",
-		options(nostack),
-	);
+	asm!("ic iallu", "tlbi vmalle1is", "dsb ish", options(nostack),);
 
 	/*
 	 * Setup memory attribute type tables
@@ -134,14 +130,14 @@ unsafe fn pre_init() -> ! {
 
 	// determine physical address size
 	asm!("mrs x0, id_aa64mmfr0_el1",
-        "and x0, x0, 0xF",
-        "lsl x0, x0, 32",
-        "orr x0, x0, {tcr_bits}",
-        "mrs x1, id_aa64mmfr0_el1",
-        "bfi x0, x1, #32, #3",
-        "msr tcr_el1, x0",
+		"and x0, x0, 0xF",
+		"lsl x0, x0, 32",
+		"orr x0, x0, {tcr_bits}",
+		"mrs x1, id_aa64mmfr0_el1",
+		"bfi x0, x1, #32, #3",
+		"msr tcr_el1, x0",
 		tcr_bits = in(reg) tcr_size(VA_BITS) | TCR_TG1_4K | TCR_FLAGS,
-        out("x0") _,
+		out("x0") _,
 		out("x1") _,
 	);
 

--- a/src/arch/aarch64/entry.s
+++ b/src/arch/aarch64/entry.s
@@ -1,0 +1,26 @@
+// Adapted from https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/blob/master/02_runtime_init/src/_arch/aarch64/cpu/boot.s
+
+.equ _core_id_mask, 0b11    //Assume 4 core raspi3
+
+.section .text._start
+
+_start:
+	// Only proceed on the boot core. Park it otherwise.
+	mrs	x1, MPIDR_EL1
+	and	x1, x1, _core_id_mask
+	mov	x2, 0      // Assume CPU 0 is responsible for booting
+	cmp	x1, x2
+	b.ne	1f
+
+	// If execution reaches here, it is the boot core. Now, prepare the jump to Rust code.
+
+	// Jump to Rust code.
+	b	_start_rust
+
+	// Infinitely wait for events (aka "park the core").
+1:	wfe
+	b	1b
+
+.size	_start, . - _start
+.type	_start, function
+.global	_start

--- a/src/arch/aarch64/link.ld
+++ b/src/arch/aarch64/link.ld
@@ -3,7 +3,7 @@ OUTPUT_ARCH("aarch64")
 ENTRY(_start)
 
 /* start address of the RAM, below belongs to the flash */
-phys = 0x40080000;
+phys = 0x00080000;
 
 SECTIONS
 {

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -55,6 +55,5 @@ pub unsafe fn boot_kernel(virtual_address: u64, mem_size: u64, entry_point: u64)
 
 	let func: extern "C" fn(boot_info: &'static mut BootInfo) -> ! =
 		core::mem::transmute(entry_point);
-
-	func(&mut BOOT_INFO);
+	func(&mut BOOT_INFO)
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -14,6 +14,14 @@ pub struct Console;
 /// a message to HermitCore's console.
 impl fmt::Write for Console {
 	/// Print a single character.
+	#[cfg(feature = "aarch64-qemu-stdout")]
+	fn write_char(&mut self, c: char) -> fmt::Result {
+		unsafe {
+			core::ptr::write_volatile(0x3F20_1000 as *mut u8, c as u8); //qemu raspi3
+		}
+		Ok(())
+	}
+	#[cfg(not(feature = "aarch64-qemu-stdout"))]
 	fn write_char(&mut self, c: char) -> fmt::Result {
 		arch::output_message_byte(c as u8);
 		Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 #![feature(const_raw_ptr_to_usize_cast)]
 #![feature(lang_items)]
 #![feature(llvm_asm)]
+#![feature(global_asm)]
+#![feature(asm)]
 #![feature(panic_info_message)]
 #![feature(specialization)]
 #![feature(naked_functions)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ pub unsafe extern "C" fn loader_main() -> ! {
 
 	let app = arch::find_kernel();
 	let elf = elf::Elf::parse(&app).expect("Unable to parse ELF file");
+	assert_ne!(elf.entry, 0, "Goblin failed to find entry point of the kernel in the Elf header");
 	let mem_size = check_kernel_elf_file(&elf);
 	let (kernel_location, entry_point) = load_kernel(&elf, app.as_ptr() as u64, mem_size);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,5 +42,5 @@ pub unsafe extern "C" fn loader_main() -> ! {
 	let (kernel_location, entry_point) = load_kernel(&elf, app.as_ptr() as u64, mem_size);
 
 	// boot kernel
-	arch::boot_kernel(kernel_location, mem_size, entry_point);
+	arch::boot_kernel(kernel_location, mem_size, entry_point)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,10 @@ pub unsafe extern "C" fn loader_main() -> ! {
 
 	let app = arch::find_kernel();
 	let elf = elf::Elf::parse(&app).expect("Unable to parse ELF file");
-	assert_ne!(elf.entry, 0, "Goblin failed to find entry point of the kernel in the Elf header");
+	assert_ne!(
+		elf.entry, 0,
+		"Goblin failed to find entry point of the kernel in the Elf header"
+	);
 	let mem_size = check_kernel_elf_file(&elf);
 	let (kernel_location, entry_point) = load_kernel(&elf, app.as_ptr() as u64, mem_size);
 


### PR DESCRIPTION
Qemu supports the raspi3 target (I'm running `qemu-system-aarch64 -display none -smp 4 -m 1G -serial stdio -kernel target/aarch64-unknown-hermit-loader/debug/rusty-loader  -machine raspi3`)
These commits add some support for raspi3, so that I could at least successfully boot into the kernel. A lot of fields in BOOT_INFO are not initialized correctly though.
Some things like the value  `phys` in `link.ld` should also be set through some board-specific files. 

Some commits also only aim to simply improve readability or convert the llvm_asm! to the asm! macro.

I'm leaving this here for discussion for now.