### PR TITLE
Add Aarch64 test

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -49,3 +49,6 @@ jobs:
       if: ${{ matrix.os == 'macOS-latest' }}
     - name: Build loader (unix)
       run: make arch=aarch64
+    - name: Test loader
+      run: qemu-system-aarch64 -display none -smp 4 -m 1G -serial stdio -kernel target/aarch64-unknown-hermit-loader/debug/rusty-loader -machine raspi3 -semihosting
+      timeout-minutes: 1

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 # Todo - make this feature toggleable
 ifeq ($(arch), aarch64)
 opt += --features "aarch64-qemu-stdout"
-export HERMIT_APP ?= "$(PWD)/data/hello_world"
+export HERMIT_APP ?= "$(PWD)/data/hello_world_aarch64"
 endif
 
 CONVERT :=

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 # Todo - make this feature toggleable
 ifeq ($(arch), aarch64)
 opt += --features "aarch64-qemu-stdout"
-export HERMIT_APP ?= "$(PWD)/data/hello_world_aarch64"
+export HERMIT_APP ?= $(PWD)/data/hello_world_aarch64
 endif
 
 CONVERT :=
@@ -42,5 +42,6 @@ docs:
 
 loader:
 	@echo Build loader
+	echo "hermit app: $(HERMIT_APP)"
 	cargo build $(opt) -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target $(target)-loader.json
 	$(CONVERT)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 arch ?= x86_64
 target ?= $(arch)-unknown-hermit
 release ?= 0
-app ?= "$(PWD)/data/hello_world"
 
 opt :=
 rdir := debug
@@ -14,6 +13,7 @@ endif
 # Todo - make this feature toggleable
 ifeq ($(arch), aarch64)
 opt += --features "aarch64-qemu-stdout"
+export HERMIT_APP ?= "$(PWD)/data/hello_world"
 endif
 
 CONVERT :=
@@ -42,5 +42,5 @@ docs:
 
 loader:
 	@echo Build loader
-	HERMIT_APP=$(app) cargo build $(opt) -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target $(target)-loader.json
+	cargo build $(opt) -Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem --target $(target)-loader.json
 	$(CONVERT)

--- a/data/hello_world_aarch64
+++ b/data/hello_world_aarch64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c72c4468397a3f1989401d2475b0036f3a336e74ff780323bbbdeb41869cf213
+size 17259744

--- a/src/arch/aarch64/entry.rs
+++ b/src/arch/aarch64/entry.rs
@@ -11,11 +11,7 @@ extern "C" {
 	fn loader_main();
 }
 
-const BOOT_STACK_SIZE: usize = 4096;
 const BOOT_CORE_ID: u64 = 0; // ID of CPU for booting on SMP systems - this might be board specific in the future
-
-#[link_section = ".data"]
-static STACK: [u8; BOOT_STACK_SIZE] = [0; BOOT_STACK_SIZE];
 
 /*
  * Memory types available.
@@ -57,10 +53,6 @@ global_asm!(include_str!("entry.s"));
 #[inline(never)]
 #[no_mangle]
 pub unsafe fn _start_rust() -> ! {
-	// Pointer to stack base
-	llvm_asm!("mov sp, $0"
-		:: "r"(&STACK[BOOT_STACK_SIZE - 0x10] as *const u8 as usize)
-        :: "volatile");
 	pre_init()
 }
 

--- a/src/arch/aarch64/link.ld
+++ b/src/arch/aarch64/link.ld
@@ -1,3 +1,7 @@
+/* Parts of this linker script are directly taken from Andre Richters Project:
+ * https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/blob/master/16_virtual_mem_part4_higher_half_kernel/src/bsp/raspberrypi/link.ld 
+*/
+
 OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH("aarch64")
 ENTRY(_start)
@@ -5,27 +9,56 @@ ENTRY(_start)
 /* start address of the RAM, below belongs to the flash */
 phys = 0x00080000;
 
+PHDRS
+{
+    segment_rx PT_LOAD FLAGS(5); /* 5 == RX */
+    segment_rw PT_LOAD FLAGS(6); /* 6 == RW */
+}
+
 SECTIONS
 {
   . = phys;
   kernel_start = .;
-  .text ALIGN(4096) : AT(ADDR(.text)) {
-    *(.text)
-    *(.text.*)
-  }
-  .rodata ALIGN(4096) : AT(ADDR(.rodata)) {
-    *(.rodata)
-    *(.rodata.*)
-  }
-  .data ALIGN(4096) : AT(ADDR(.data)) {
-    *(.data)
-    *(.data.*)
-  }
-  .bss ALIGN(4096) : AT(ADDR(.bss)) {
+  __rx_start = .;
+  .text ALIGN(4096) : AT(phys) {
+      KEEP(*(.text._start))
+      *(.text._start_arguments) /* Constants (or statics in Rust speak) read by _start(). */
+      *(.text._start_rust)      /* The Rust entry point */
+      *(.text*)                 /* Everything else */
+  } :segment_rx
+  .rodata : ALIGN(8) { *(.rodata*) } :segment_rx
+  .got    : ALIGN(8) { *(.got)     } :segment_rx /* Global offset table Todo - do we use this?*/
+  . = ALIGN(64K); /* Align to page boundary */
+  __rx_end_exclusive = .;
+
+  __rw_start = .;
+  .data : { *(.data*) } :segment_rw
+
+  .bss : ALIGN(8) {
     bss_start = .;
-    *(.bss)
-    *(.bss.*)
-  }
-  bss_end = .;
+    *(.bss*);
+    . = ALIGN(8);
+    . += 8;
+    bss_end = .;
+  } :NONE
+
+  . = ALIGN(64K); /* Align to page boundary */
+  __rw_end_exclusive = .;
+
+  /***********************************************************************************************
+  * Guard Page between boot core stack and data
+  ***********************************************************************************************/
+  __boot_core_stack_guard_page_start = .;
+  . += 64K;
+  __boot_core_stack_guard_page_end_exclusive = .;
+
+  /***********************************************************************************************
+  * Boot Core Stack
+  ***********************************************************************************************/
+  __boot_core_stack_start = .;         /*   ^             */
+                                       /*   | stack       */
+  . += 512K;                           /*   | growth      */
+                                       /*   | direction   */
+  __boot_core_stack_end_exclusive = .; /*   |             */
   kernel_end = .;
 }


### PR DESCRIPTION
This PR adds an aarch64 artifact of the hermit application (for use with the github workflow) that will exit once it reaches the point up to which the kernel currently works. Expected Output is something like:

```
$ qemu-system-aarch64 -display none -smp 4 -m 1G -serial stdio -kernel target/aarch64-unknown-hermit-loader/debug/rusty-loader  -machine raspi3 -semihosting
[LOADER] Enter startup code
[LOADER] Loader: [0x80000 - 0x131a010]
[LOADER] Allocating 0x268 bytes at 0x11190C0, index 0
[LOADER] Allocating 0x870 bytes at 0x1119340, index 640
[LOADER] Allocating 0xC0 bytes at 0x1119BC0, index 2816
[LOADER] Allocating 0xE0 bytes at 0x1119CC0, index 3072
[LOADER] This is a supported HermitCore Application
[LOADER] Found entry point: 0x500f4
[LOADER] File Size: 488897 Bytes
[LOADER] Mem Size:  522008 Bytes
[LOADER] start 0x9a2cc, size 0x7f718
[LOADER] Load HermitCore Application at 0x1200000
[LOADER] Found TLS starts at 0x1250200 (size 88 Bytes)
[LOADER] Jumping to HermitCore Application Entry Point at 0x12500f4
Welcome to hermit kernel.
[0][INFO] Welcome to HermitCore-rs 0.3.45
[0][INFO] Kernel starts at 0x0
[0][INFO] BSS starts at 0x12775c8
[0][INFO] TLS starts at 0x0 (size 0 Bytes)
[0][INFO] The current hermit-kernel is only implemented up to this point on aarch64.
[0][INFO] Attempting to exit via QEMU.
[0][INFO] This requires that you passed the `-semihosting` option to QEMU.
```

This test compiles the rusty-loader with an application artifact compiled from
    https://github.com/jschwe/libhermit-rs/commit/f5faa6d059f29e6a4d28a8872acf639c64d3a6ae
    The artifact is technically the rusty_demo artifact, since the hello_world artifact
    didn't work for me.
    ~~This is most likely due to the loader still being brittle.
    I suspect that the copying process is buggy, since (un)commenting simple things
    such as log messages in rusty-loader will break or fix entry into the kernel.
    Until this is fixed this workflow will probably fail sometimes.~~

Update: Commit ae3308c changes the way the Stack pointer is set and this seems to fix the issues I'd been having.