### PR TITLE
target json: Remove eliminate-frame-pointer field

### DIFF
--- a/aarch64-unknown-hermit-loader.json
+++ b/aarch64-unknown-hermit-loader.json
@@ -9,7 +9,6 @@
     "arch": "aarch64",
     "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
     "features": "+a53,+strict-align,-fp-armv8",
-    "eliminate-frame-pointer": true,
     "executables": true,
     "relocation-model": "static",
     "panic-strategy": "abort"

--- a/x86_64-unknown-hermit-loader.json
+++ b/x86_64-unknown-hermit-loader.json
@@ -10,7 +10,6 @@
     "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
     "disable-redzone": true,
-    "eliminate-frame-pointer": true,
     "executables": true,
     "panic-strategy": "abort"
 }


### PR DESCRIPTION
Resolves
warning: target json file contains unused fields: eliminate-frame-pointer