### PR TITLE
Downgrade goblin to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "goblin"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1800b95efee8ad4ef04517d4d69f8e209e763b1668f1179aeeedd0e454da55"
+checksum = "ee05c709047abe5eb0571880d2887ac77299c5f0835f8e6b7f4d5404f8962921"
 dependencies = [
  "log",
  "plain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ aarch64-qemu-stdout = []    # Output to special qemu address 0x3F20_1000 instead
 
 [dependencies]
 bitflags = "1.3"
-goblin = { version = "0.4", default-features = false, features = ["elf64", "elf32", "endian_fd"] }
+goblin = { version = "0.4.1", default-features = false, features = ["elf64", "elf32", "endian_fd"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 multiboot = "0.7"


### PR DESCRIPTION
This is a workaround for https://github.com/hermitcore/rusty-loader/issues/32.