### PR TITLE
add support of static binaries

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -13,17 +13,12 @@ on:
 jobs:
   build:
     name: Test aarch64
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
         rust: [nightly]
         include:
-          - os: macOS-latest
-            rust: 'nightly'
-            components: 'rust-src, llvm-tools-preview'
-            targets: 'aarch64-apple-darwin'
           - os: ubuntu-latest
             rust: 'nightly'
             components: 'rust-src, llvm-tools-preview'
@@ -40,13 +35,9 @@ jobs:
           lfs: true
     - name: Check Cargo availability
       run: cargo --version
-    - name: Install qemu (apt)
+    - name: Install qemu
       run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-aarch64
       if: ${{ matrix.os == 'ubuntu-latest' }}
-    - name: Install qemu (macos)
-      run: |
-          brew install qemu
-      if: ${{ matrix.os == 'macOS-latest' }}
     - name: Build loader (unix)
       run: make arch=aarch64
     - name: Print list of machine types

--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -49,6 +49,8 @@ jobs:
       if: ${{ matrix.os == 'macOS-latest' }}
     - name: Build loader (unix)
       run: make arch=aarch64
+    - name: Print list of machine types
+      run: qemu-system-aarch64 -machine ?
     - name: Test loader
       run: qemu-system-aarch64 -display none -smp 4 -m 1G -serial stdio -kernel target/aarch64-unknown-hermit-loader/debug/rusty-loader -machine raspi3 -semihosting
       timeout-minutes: 1

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,5 @@
 status = [
-  "Test aarch64 (ubuntu-latest, nightly)",
-  "Test aarch64 (macOS-latest, nightly)",
+  "Test aarch64 (nightly)",
   "Test x86_64 (ubuntu-latest, nightly)",
   "Test x86_64 (macOS-latest, nightly)",
   "Format check (ubuntu-latest, nightly)",

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -37,7 +37,12 @@ pub fn find_kernel() -> &'static [u8] {
 	include_bytes!(env!("HERMIT_APP"))
 }
 
-pub unsafe fn boot_kernel(virtual_address: u64, mem_size: u64, entry_point: u64) -> ! {
+pub unsafe fn boot_kernel(
+	_elf_address: Option<u64>,
+	virtual_address: u64,
+	mem_size: u64,
+	entry_point: u64,
+) -> ! {
 	// Jump to the kernel entry point and provide the Multiboot information to it.
 	loaderlog!(
 		"Jumping to HermitCore Application Entry Point at {:#x}",

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -54,18 +54,22 @@ pub fn check_kernel_elf_file(elf: &Elf<'_>) -> u64 {
 	}
 
 	// Verify that this module is a HermitCore ELF executable.
-	assert!(elf.header.e_type == header::ET_DYN);
 	assert!(elf.header.e_machine == arch::ELF_ARCH);
 	loaderlog!("This is a supported HermitCore Application");
 
 	// Get all necessary information about the ELF executable.
 	let mut file_size: u64 = 0;
 	let mut mem_size: u64 = 0;
+	let mut start_addr: u64 = u64::MAX;
 
 	for program_header in &elf.program_headers {
 		if program_header.p_type == program_header::PT_LOAD {
-			file_size = program_header.p_vaddr + program_header.p_filesz;
-			mem_size = program_header.p_vaddr + program_header.p_memsz;
+			if start_addr == u64::MAX {
+				start_addr = program_header.p_vaddr;
+			}
+
+			file_size += program_header.p_filesz;
+			mem_size = program_header.p_vaddr + program_header.p_memsz - start_addr;
 		}
 	}
 
@@ -79,7 +83,7 @@ pub fn check_kernel_elf_file(elf: &Elf<'_>) -> u64 {
 	mem_size
 }
 
-pub unsafe fn load_kernel(elf: &Elf<'_>, elf_start: u64, mem_size: u64) -> (u64, u64) {
+pub unsafe fn load_kernel(elf: &Elf<'_>, elf_start: u64, mem_size: u64) -> (Option<u64>, u64, u64) {
 	loaderlog!("start {:#x}, size {:#x}", elf_start, mem_size);
 	if !elf.libraries.is_empty() {
 		panic!(
@@ -89,7 +93,6 @@ pub unsafe fn load_kernel(elf: &Elf<'_>, elf_start: u64, mem_size: u64) -> (u64,
 	}
 
 	// Verify that this module is a HermitCore ELF executable.
-	assert!(elf.header.e_type == header::ET_DYN);
 	assert!(elf.header.e_machine == arch::ELF_ARCH);
 
 	if elf.header.e_ident[7] != 0xFF {
@@ -99,10 +102,17 @@ pub unsafe fn load_kernel(elf: &Elf<'_>, elf_start: u64, mem_size: u64) -> (u64,
 	let address = get_memory(mem_size);
 	loaderlog!("Load HermitCore Application at {:#x}", address);
 
+	let mut p_vaddr: u64 = u64::MAX;
+
 	// load application
 	for program_header in &elf.program_headers {
 		if program_header.p_type == program_header::PT_LOAD {
-			let pos = program_header.p_vaddr;
+			if p_vaddr == u64::MAX {
+				p_vaddr = program_header.p_vaddr;
+			}
+
+			// relative position to the kernel location
+			let pos = program_header.p_vaddr - p_vaddr;
 
 			copy_nonoverlapping(
 				(elf_start + program_header.p_offset) as *const u8,
@@ -117,9 +127,13 @@ pub unsafe fn load_kernel(elf: &Elf<'_>, elf_start: u64, mem_size: u64) -> (u64,
 					.unwrap(),
 			);
 		} else if program_header.p_type == program_header::PT_TLS {
-			BOOT_INFO.tls_start = address + program_header.p_vaddr as u64;
-			BOOT_INFO.tls_filesz = program_header.p_filesz as u64;
-			BOOT_INFO.tls_memsz = program_header.p_memsz as u64;
+			if elf.header.e_type == header::ET_DYN {
+				BOOT_INFO.tls_start = address + u64::from(program_header.p_vaddr);
+			} else {
+				BOOT_INFO.tls_start = program_header.p_vaddr.into();
+			}
+			BOOT_INFO.tls_filesz = program_header.p_filesz.into();
+			BOOT_INFO.tls_memsz = program_header.p_memsz.into();
 			BOOT_INFO.tls_align = program_header.p_align;
 
 			loaderlog!(
@@ -135,26 +149,14 @@ pub unsafe fn load_kernel(elf: &Elf<'_>, elf_start: u64, mem_size: u64) -> (u64,
 		loaderlog!("Unsupported relocation type {}", rel.r_type);
 	}
 
-	extern "C" {
-		static kernel_end: u8;
-	}
-
 	// relocate entries (strings, copy-data, etc.) with an addend
 	for rela in &elf.dynrelas {
 		match rela.r_type {
-			#[cfg(target_arch = "x86_64")]
-			reloc::R_X86_64_RELATIVE => {
-				use crate::arch::x86_64::paging::{LargePageSize, PageSize};
-
+			reloc::R_X86_64_RELATIVE | reloc::R_AARCH64_RELATIVE => {
 				let offset = (address + rela.r_offset) as *mut u64;
-				let new_addr =
-					align_up!(&kernel_end as *const u8 as usize, LargePageSize::SIZE) as u64;
-				*offset = (new_addr as i64 + rela.r_addend.unwrap_or(0)) as u64;
-			}
-			#[cfg(target_arch = "aarch64")]
-			reloc::R_AARCH64_RELATIVE => {
-				let offset = (address + rela.r_offset) as *mut u64;
-				*offset = (address as i64 + rela.r_addend.unwrap_or(0)) as u64;
+				*offset = (address as i64 + rela.r_addend.unwrap_or(0))
+					.try_into()
+					.unwrap();
 			}
 			_ => {
 				loaderlog!("Unsupported relocation type {}", rela.r_type);
@@ -162,5 +164,9 @@ pub unsafe fn load_kernel(elf: &Elf<'_>, elf_start: u64, mem_size: u64) -> (u64,
 		}
 	}
 
-	(address, elf.entry + address)
+	if elf.header.e_type == header::ET_DYN {
+		(None, address, elf.entry + address)
+	} else {
+		(Some(p_vaddr), address, elf.entry)
+	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,9 @@ pub unsafe extern "C" fn loader_main() -> ! {
 		"Goblin failed to find entry point of the kernel in the Elf header"
 	);
 	let mem_size = kernel::check_kernel_elf_file(&elf);
-	let (kernel_location, entry_point) = kernel::load_kernel(&elf, app.as_ptr() as u64, mem_size);
+	let (elf_location, kernel_location, entry_point) =
+		kernel::load_kernel(&elf, app.as_ptr() as u64, mem_size);
 
 	// boot kernel
-	arch::boot_kernel(kernel_location, mem_size, entry_point)
+	arch::boot_kernel(elf_location, kernel_location, mem_size, entry_point)
 }


### PR DESCRIPTION
The C user space does (currently) not support dynamic binaries and
the support of static binaries has to be reactivate.

In addition, moving of the dynamic binary is avoided to reduce boot time.