### PR TITLE
Add riscv64 support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,5 +12,10 @@ rustflags = [
   "-C", "link-arg=-Tsrc/arch/aarch64/link.ld"
 ]
 
+[target.riscv64imac-unknown-none-elf]
+rustflags = [
+  "-C", "link-arg=-Tsrc/arch/riscv/link.ld"
+]
+
 [build]
 target = "x86_64-unknown-hermit-loader.json"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,16 +12,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "0.1.7"
+name = "aho-corasick"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bare-metal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
 name = "bit_field"
@@ -66,6 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
+name = "fdt"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b643857cf70949306b81d7e92cb9d47add673868edac9863c4a49c42feaf3f1e"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,10 +113,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 
 [[package]]
-name = "libc"
-version = "0.2.101"
+name = "lazy_static"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "log"
@@ -102,6 +132,12 @@ checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "multiboot"
@@ -127,14 +163,14 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "phf"
@@ -182,18 +218,18 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -204,7 +240,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "libc",
  "rand_chacha",
  "rand_core 0.4.2",
@@ -223,7 +259,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "rand_core 0.3.1",
 ]
 
@@ -291,7 +327,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "rand_core 0.4.2",
 ]
 
@@ -323,14 +359,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "riscv"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
+dependencies = [
+ "bare-metal",
+ "bit_field",
+ "riscv-target",
+]
+
+[[package]]
+name = "riscv-target"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "rusty-loader"
 version = "0.2.6"
 dependencies = [
  "aarch64",
  "bitflags",
+ "fdt",
  "goblin",
  "multiboot",
+ "riscv",
  "target_build_utils",
+ "trapframe",
  "x86",
 ]
 
@@ -380,9 +457,9 @@ checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -407,10 +484,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee8fba06c1f4d0b396ef61a54530bb6b28f0dc61c38bc8bc5a5a48161e6282e"
 
 [[package]]
+name = "trapframe"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f287ee70169f5bfddba441baf901b620e3655f16fa7815f48a7e100ec6d86a8f"
+dependencies = [
+ "raw-cpuid",
+ "x86_64",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "volatile"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c2dbd44eb8b53973357e6e207e370f0c1059990df850aca1eca8947cf464f0"
 
 [[package]]
 name = "winapi"
@@ -443,4 +536,15 @@ dependencies = [
  "bit_field",
  "bitflags",
  "raw-cpuid",
+]
+
+[[package]]
+name = "x86_64"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958ab3202b01bc43ba2eb832102c4a487ed93151667a2289062e5f2b00058be2"
+dependencies = [
+ "bit_field",
+ "bitflags",
+ "volatile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,15 @@ edition = "2021"
 bitflags = "1.3"
 goblin = { version = "0.4", default-features = false, features = ["elf64", "elf32", "endian_fd"] }
 
+[target.'cfg(target_arch = "riscv64")'.dependencies.riscv]
+version = "0.7.0"
+
+[target.'cfg(target_arch = "riscv64")'.dependencies.fdt]
+version = "0.1"
+
+[target.'cfg(target_arch = "riscv64")'.dependencies.trapframe]
+version = "0.9.0"
+
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 multiboot = "0.7"
 x86 = { version = "0.45", default-features = false }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -4,8 +4,14 @@ pub use crate::arch::x86_64::*;
 #[cfg(target_arch = "aarch64")]
 pub use crate::arch::aarch64::*;
 
+#[cfg(target_arch = "riscv64")]
+pub use crate::arch::riscv::*;
+
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
+
+#[cfg(target_arch = "riscv64")]
+pub mod riscv;

--- a/src/arch/riscv/addr.rs
+++ b/src/arch/riscv/addr.rs
@@ -1,0 +1,709 @@
+use core::convert::{From, Into};
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::ops;
+
+/// Align address downwards.
+///
+/// Returns the greatest x with alignment `align` so that x <= addr.
+/// The alignment must be a power of 2.
+#[inline(always)]
+fn align_down(addr: u64, align: u64) -> u64 {
+	addr & !(align - 1)
+}
+
+/// Align address upwards.
+///
+/// Returns the smallest x with alignment `align` so that x >= addr.
+/// The alignment must be a power of 2.
+#[inline(always)]
+fn align_up(addr: u64, align: u64) -> u64 {
+	let align_mask = align - 1;
+	if addr & align_mask == 0 {
+		addr
+	} else {
+		(addr | align_mask) + 1
+	}
+}
+
+/// A wrapper for a physical address, which is in principle
+/// derived from the crate x86.
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PhysAddr(pub u64);
+
+impl PhysAddr {
+	/// Convert to `u64`
+	pub fn as_u64(self) -> u64 {
+		self.0
+	}
+
+	/// Convert to `usize`
+	pub fn as_usize(self) -> usize {
+		self.0 as usize
+	}
+
+	/// Physical Address zero.
+	pub const fn zero() -> Self {
+		PhysAddr(0)
+	}
+
+	/// Is zero?
+	pub fn is_zero(self) -> bool {
+		self == PhysAddr::zero()
+	}
+
+	#[allow(dead_code)]
+	fn align_up<U>(self, align: U) -> Self
+	where
+		U: Into<u64>,
+	{
+		PhysAddr(align_up(self.0, align.into()))
+	}
+
+	fn align_down<U>(self, align: U) -> Self
+	where
+		U: Into<u64>,
+	{
+		PhysAddr(align_down(self.0, align.into()))
+	}
+
+	/// Is this address aligned to `align`?
+	///
+	/// # Note
+	/// `align` must be a power of two.
+	pub fn is_aligned<U>(self, align: U) -> bool
+	where
+		U: Into<u64> + Copy,
+	{
+		if !align.into().is_power_of_two() {
+			return false;
+		}
+
+		self.align_down(align) == self
+	}
+}
+
+impl From<u64> for PhysAddr {
+	fn from(num: u64) -> Self {
+		PhysAddr(num)
+	}
+}
+
+impl From<usize> for PhysAddr {
+	fn from(num: usize) -> Self {
+		PhysAddr(num as u64)
+	}
+}
+
+impl From<i32> for PhysAddr {
+	fn from(num: i32) -> Self {
+		PhysAddr(num as u64)
+	}
+}
+
+impl Into<u64> for PhysAddr {
+	fn into(self) -> u64 {
+		self.0
+	}
+}
+
+impl Into<usize> for PhysAddr {
+	fn into(self) -> usize {
+		self.0 as usize
+	}
+}
+
+impl ops::Add for PhysAddr {
+	type Output = PhysAddr;
+
+	fn add(self, rhs: PhysAddr) -> Self::Output {
+		PhysAddr(self.0 + rhs.0)
+	}
+}
+
+impl ops::Add<u64> for PhysAddr {
+	type Output = PhysAddr;
+
+	fn add(self, rhs: u64) -> Self::Output {
+		PhysAddr::from(self.0 + rhs)
+	}
+}
+
+impl ops::Add<usize> for PhysAddr {
+	type Output = PhysAddr;
+
+	fn add(self, rhs: usize) -> Self::Output {
+		PhysAddr::from(self.0 + rhs as u64)
+	}
+}
+
+impl ops::AddAssign for PhysAddr {
+	fn add_assign(&mut self, other: PhysAddr) {
+		*self = PhysAddr::from(self.0 + other.0);
+	}
+}
+
+impl ops::AddAssign<u64> for PhysAddr {
+	fn add_assign(&mut self, offset: u64) {
+		*self = PhysAddr::from(self.0 + offset);
+	}
+}
+
+impl ops::Sub for PhysAddr {
+	type Output = PhysAddr;
+
+	fn sub(self, rhs: PhysAddr) -> Self::Output {
+		PhysAddr::from(self.0 - rhs.0)
+	}
+}
+
+impl ops::Sub<u64> for PhysAddr {
+	type Output = PhysAddr;
+
+	fn sub(self, rhs: u64) -> Self::Output {
+		PhysAddr::from(self.0 - rhs)
+	}
+}
+
+impl ops::Sub<usize> for PhysAddr {
+	type Output = PhysAddr;
+
+	fn sub(self, rhs: usize) -> Self::Output {
+		PhysAddr::from(self.0 - rhs as u64)
+	}
+}
+
+impl ops::Rem for PhysAddr {
+	type Output = PhysAddr;
+
+	fn rem(self, rhs: PhysAddr) -> Self::Output {
+		PhysAddr(self.0 % rhs.0)
+	}
+}
+
+impl ops::Rem<u64> for PhysAddr {
+	type Output = u64;
+
+	fn rem(self, rhs: u64) -> Self::Output {
+		self.0 % rhs
+	}
+}
+
+impl ops::Rem<usize> for PhysAddr {
+	type Output = u64;
+
+	fn rem(self, rhs: usize) -> Self::Output {
+		self.0 % (rhs as u64)
+	}
+}
+
+impl ops::BitAnd for PhysAddr {
+	type Output = Self;
+
+	fn bitand(self, rhs: Self) -> Self {
+		PhysAddr(self.0 & rhs.0)
+	}
+}
+
+impl ops::BitAnd<u64> for PhysAddr {
+	type Output = u64;
+
+	fn bitand(self, rhs: u64) -> Self::Output {
+		Into::<u64>::into(self) & rhs
+	}
+}
+
+impl ops::BitOr for PhysAddr {
+	type Output = PhysAddr;
+
+	fn bitor(self, rhs: PhysAddr) -> Self::Output {
+		PhysAddr(self.0 | rhs.0)
+	}
+}
+
+impl ops::BitOr<u64> for PhysAddr {
+	type Output = u64;
+
+	fn bitor(self, rhs: u64) -> Self::Output {
+		self.0 | rhs
+	}
+}
+
+impl ops::Shr<u64> for PhysAddr {
+	type Output = u64;
+
+	fn shr(self, rhs: u64) -> Self::Output {
+		self.0 >> rhs
+	}
+}
+
+impl fmt::Binary for PhysAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl fmt::Display for PhysAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl fmt::Debug for PhysAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{:#x}", self.0)
+	}
+}
+
+impl fmt::LowerHex for PhysAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl fmt::Octal for PhysAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl fmt::UpperHex for PhysAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl fmt::Pointer for PhysAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		use core::fmt::LowerHex;
+		self.0.fmt(f)
+	}
+}
+
+impl Hash for PhysAddr {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.0.hash(state);
+	}
+}
+
+/// A wrapper for a virtual address, which is in principle
+/// derived from the crate x86.
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub struct VirtAddr(pub u64);
+
+impl VirtAddr {
+	/// Convert from `u64`
+	pub const fn from_u64(v: u64) -> Self {
+		VirtAddr(v)
+	}
+
+	/// Convert from `usize`
+	pub const fn from_usize(v: usize) -> Self {
+		VirtAddr(v as u64)
+	}
+
+	/// Convert to `u64`
+	pub const fn as_u64(self) -> u64 {
+		self.0
+	}
+
+	/// Convert to `usize`
+	pub const fn as_usize(self) -> usize {
+		self.0 as usize
+	}
+
+	/// Convert to mutable pointer.
+	pub fn as_mut_ptr<T>(self) -> *mut T {
+		self.0 as *mut T
+	}
+
+	/// Convert to pointer.
+	pub fn as_ptr<T>(self) -> *const T {
+		self.0 as *const T
+	}
+
+	/// Physical Address zero.
+	pub const fn zero() -> Self {
+		VirtAddr(0)
+	}
+
+	/// Is zero?
+	pub fn is_zero(self) -> bool {
+		self == VirtAddr::zero()
+	}
+
+	fn align_up<U>(self, align: U) -> Self
+	where
+		U: Into<u64>,
+	{
+		VirtAddr(align_up(self.0, align.into()))
+	}
+
+	fn align_down<U>(self, align: U) -> Self
+	where
+		U: Into<u64>,
+	{
+		VirtAddr(align_down(self.0, align.into()))
+	}
+
+	/// Offset within the 4 KiB page.
+	pub fn base_page_offset(self) -> u64 {
+		self.0 & (BASE_PAGE_SIZE as u64 - 1)
+	}
+
+	/// Offset within the 2 MiB page.
+	pub fn large_page_offset(self) -> u64 {
+		self.0 & (MEGA_PAGE_SIZE as u64 - 1)
+	}
+
+	/// Offset within the 1 GiB page.
+	pub fn giga_page_offset(self) -> u64 {
+		self.0 & (GIGA_PAGE_SIZE as u64 - 1)
+	}
+
+	/// Offset within the 512 GiB page.
+	pub fn tera_page_offset(self) -> u64 {
+		self.0 & (TERA_PAGE_SIZE as u64 - 1)
+	}
+
+	/// Return address of nearest 4 KiB page (lower or equal than self).
+	pub fn align_down_to_base_page(self) -> Self {
+		self.align_down(BASE_PAGE_SIZE as u64)
+	}
+
+	/// Return address of nearest 2 MiB page (lower or equal than self).
+	pub fn align_down_to_large_page(self) -> Self {
+		self.align_down(MEGA_PAGE_SIZE as u64)
+	}
+
+	/// Return address of nearest 1 GiB page (lower or equal than self).
+	pub fn align_down_to_giga_page(self) -> Self {
+		self.align_down(GIGA_PAGE_SIZE as u64)
+	}
+
+	/// Return address of nearest 512 GiB page (lower or equal than self).
+	pub fn align_down_to_tera_page(self) -> Self {
+		self.align_down(TERA_PAGE_SIZE as u64)
+	}
+
+	/// Return address of nearest 4 KiB page (higher or equal than self).
+	pub fn align_up_to_base_page(self) -> Self {
+		self.align_up(BASE_PAGE_SIZE as u64)
+	}
+
+	/// Return address of nearest 2 MiB page (higher or equal than self).
+	pub fn align_up_to_large_page(self) -> Self {
+		self.align_up(MEGA_PAGE_SIZE as u64)
+	}
+
+	/// Return address of nearest 1 GiB page (higher or equal than self).
+	pub fn align_up_to_giga_page(self) -> Self {
+		self.align_up(GIGA_PAGE_SIZE as u64)
+	}
+
+	/// Return address of nearest 512 GiB page (higher or equal than self).
+	pub fn align_up_to_tera_page(self) -> Self {
+		self.align_up(TERA_PAGE_SIZE as u64)
+	}
+
+	/// Is this address aligned to a 4 KiB page?
+	pub fn is_base_page_aligned(self) -> bool {
+		self.align_down(BASE_PAGE_SIZE as u64) == self
+	}
+
+	/// Is this address aligned to a 2 MiB page?
+	pub fn is_large_page_aligned(self) -> bool {
+		self.align_down(MEGA_PAGE_SIZE as u64) == self
+	}
+
+	/// Is this address aligned to a 1 GiB page?
+	pub fn is_giga_page_aligned(self) -> bool {
+		self.align_down(GIGA_PAGE_SIZE as u64) == self
+	}
+
+	/// Is this address aligned to a 512 GiB page?
+	pub fn is_tera_page_aligned(self) -> bool {
+		self.align_down(TERA_PAGE_SIZE as u64) == self
+	}
+
+	/// Is this address aligned to `align`?
+	///
+	/// # Note
+	/// `align` must be a power of two.
+	pub fn is_aligned<U>(self, align: U) -> bool
+	where
+		U: Into<u64> + Copy,
+	{
+		if !align.into().is_power_of_two() {
+			return false;
+		}
+
+		self.align_down(align) == self
+	}
+}
+
+impl From<u64> for VirtAddr {
+	fn from(num: u64) -> Self {
+		VirtAddr(num)
+	}
+}
+
+impl From<i32> for VirtAddr {
+	fn from(num: i32) -> Self {
+		VirtAddr(num as u64)
+	}
+}
+
+impl Into<u64> for VirtAddr {
+	fn into(self) -> u64 {
+		self.0
+	}
+}
+
+impl From<usize> for VirtAddr {
+	fn from(num: usize) -> Self {
+		VirtAddr(num as u64)
+	}
+}
+
+impl Into<usize> for VirtAddr {
+	fn into(self) -> usize {
+		self.0 as usize
+	}
+}
+
+impl ops::Add for VirtAddr {
+	type Output = VirtAddr;
+
+	fn add(self, rhs: VirtAddr) -> Self::Output {
+		VirtAddr(self.0 + rhs.0)
+	}
+}
+
+impl ops::Add<u64> for VirtAddr {
+	type Output = VirtAddr;
+
+	fn add(self, rhs: u64) -> Self::Output {
+		VirtAddr(self.0 + rhs)
+	}
+}
+
+impl ops::Add<usize> for VirtAddr {
+	type Output = VirtAddr;
+
+	fn add(self, rhs: usize) -> Self::Output {
+		VirtAddr::from(self.0 + rhs as u64)
+	}
+}
+
+impl ops::AddAssign for VirtAddr {
+	fn add_assign(&mut self, other: VirtAddr) {
+		*self = VirtAddr::from(self.0 + other.0);
+	}
+}
+
+impl ops::AddAssign<u64> for VirtAddr {
+	fn add_assign(&mut self, offset: u64) {
+		*self = VirtAddr::from(self.0 + offset);
+	}
+}
+
+impl ops::AddAssign<usize> for VirtAddr {
+	fn add_assign(&mut self, offset: usize) {
+		*self = VirtAddr::from(self.0 + offset as u64);
+	}
+}
+
+impl ops::Sub for VirtAddr {
+	type Output = VirtAddr;
+
+	fn sub(self, rhs: VirtAddr) -> Self::Output {
+		VirtAddr::from(self.0 - rhs.0)
+	}
+}
+
+impl ops::Sub<u64> for VirtAddr {
+	type Output = VirtAddr;
+
+	fn sub(self, rhs: u64) -> Self::Output {
+		VirtAddr::from(self.0 - rhs)
+	}
+}
+
+impl ops::Sub<usize> for VirtAddr {
+	type Output = VirtAddr;
+
+	fn sub(self, rhs: usize) -> Self::Output {
+		VirtAddr::from(self.0 - rhs as u64)
+	}
+}
+
+impl ops::Rem for VirtAddr {
+	type Output = VirtAddr;
+
+	fn rem(self, rhs: VirtAddr) -> Self::Output {
+		VirtAddr(self.0 % rhs.0)
+	}
+}
+
+impl ops::Rem<u64> for VirtAddr {
+	type Output = u64;
+
+	fn rem(self, rhs: Self::Output) -> Self::Output {
+		self.0 % rhs
+	}
+}
+
+impl ops::Rem<usize> for VirtAddr {
+	type Output = usize;
+
+	fn rem(self, rhs: Self::Output) -> Self::Output {
+		self.as_usize() % rhs
+	}
+}
+
+impl ops::BitAnd for VirtAddr {
+	type Output = Self;
+
+	fn bitand(self, rhs: Self) -> Self::Output {
+		VirtAddr(self.0 & rhs.0)
+	}
+}
+
+impl ops::BitAnd<u64> for VirtAddr {
+	type Output = VirtAddr;
+
+	fn bitand(self, rhs: u64) -> Self::Output {
+		VirtAddr(self.0 & rhs)
+	}
+}
+
+impl ops::BitAnd<usize> for VirtAddr {
+	type Output = VirtAddr;
+
+	fn bitand(self, rhs: usize) -> Self::Output {
+		VirtAddr(self.0 & rhs as u64)
+	}
+}
+
+impl ops::BitAnd<i32> for VirtAddr {
+	type Output = VirtAddr;
+
+	fn bitand(self, rhs: i32) -> Self::Output {
+		VirtAddr(self.0 & rhs as u64)
+	}
+}
+
+impl ops::BitOr for VirtAddr {
+	type Output = VirtAddr;
+
+	fn bitor(self, rhs: VirtAddr) -> VirtAddr {
+		VirtAddr(self.0 | rhs.0)
+	}
+}
+
+impl ops::BitOr<u64> for VirtAddr {
+	type Output = VirtAddr;
+
+	fn bitor(self, rhs: u64) -> Self::Output {
+		VirtAddr(self.0 | rhs)
+	}
+}
+
+impl ops::BitOr<usize> for VirtAddr {
+	type Output = VirtAddr;
+
+	fn bitor(self, rhs: usize) -> Self::Output {
+		VirtAddr(self.0 | rhs as u64)
+	}
+}
+
+impl ops::Shr<u64> for VirtAddr {
+	type Output = u64;
+
+	fn shr(self, rhs: u64) -> Self::Output {
+		self.0 >> rhs as u64
+	}
+}
+
+impl ops::Shr<usize> for VirtAddr {
+	type Output = u64;
+
+	fn shr(self, rhs: usize) -> Self::Output {
+		self.0 >> rhs as u64
+	}
+}
+
+impl ops::Shr<i32> for VirtAddr {
+	type Output = u64;
+
+	fn shr(self, rhs: i32) -> Self::Output {
+		self.0 >> rhs as u64
+	}
+}
+
+impl fmt::Binary for VirtAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl fmt::Display for VirtAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{:#x}", self.0)
+	}
+}
+
+impl fmt::Debug for VirtAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{:#x}", self.0)
+	}
+}
+
+impl fmt::LowerHex for VirtAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl fmt::Octal for VirtAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl fmt::UpperHex for VirtAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl fmt::Pointer for VirtAddr {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		use core::fmt::LowerHex;
+		self.0.fmt(f)
+	}
+}
+
+impl Hash for VirtAddr {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		self.0.hash(state);
+	}
+}
+
+/// Log2 of base page size (12 bits).
+pub const BASE_PAGE_SHIFT: usize = 12;
+
+/// Size of a base page (4 KiB)
+pub const BASE_PAGE_SIZE: usize = 4096;
+
+/// Size of a mega page (2 MiB)
+pub const MEGA_PAGE_SIZE: usize = 1024 * 1024 * 2;
+
+/// Size of a giga page (1 GiB)
+pub const GIGA_PAGE_SIZE: usize = 1024 * 1024 * 1024;
+
+/// Size of a tera page (512 GiB)
+pub const TERA_PAGE_SIZE: usize = 1024 * 1024 * 1024 * 512;

--- a/src/arch/riscv/bootinfo.rs
+++ b/src/arch/riscv/bootinfo.rs
@@ -1,0 +1,109 @@
+use core::fmt;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct BootInfo {
+	pub magic_number: u32,
+	pub version: u32,
+	pub base: u64,
+	pub ram_start: u64,
+	pub limit: u64,
+	pub image_size: u64,
+	pub tls_start: u64,
+	pub tls_filesz: u64,
+	pub tls_memsz: u64,
+	pub tls_align: u64,
+	pub current_stack_address: u64,
+	pub current_percore_address: u64,
+	pub host_logical_addr: u64,
+	pub boot_gtod: u64,
+	pub cmdline: u64,
+	pub cmdsize: u64,
+	pub cpu_freq: u32,
+	pub boot_processor: u32,
+	pub cpu_online: u32,
+	pub possible_cpus: u32,
+	pub current_boot_id: u32,
+	pub uartport: u32,
+	pub single_kernel: u8,
+	pub uhyve: u8,
+	pub hcip: [u8; 4],
+	pub hcgateway: [u8; 4],
+	pub hcmask: [u8; 4],
+	pub dtb_ptr: u64,
+	pub hart_mask: u64,
+	pub timebase_freq: u64,
+}
+
+impl BootInfo {
+	pub const fn new() -> Self {
+		BootInfo {
+			magic_number: 0xC0DE_CAFEu32,
+			version: 1,
+			base: 0,
+			ram_start: 0,
+			limit: 0,
+			tls_start: 0,
+			tls_filesz: 0,
+			tls_memsz: 0,
+			tls_align: 0,
+			image_size: 0,
+			current_stack_address: 0,
+			current_percore_address: 0,
+			host_logical_addr: 0,
+			boot_gtod: 0,
+			cmdline: 0,
+			cmdsize: 0,
+			cpu_freq: 0,
+			boot_processor: !0,
+			cpu_online: 0,
+			possible_cpus: 0,
+			current_boot_id: 0,
+			uartport: 0,
+			single_kernel: 1,
+			uhyve: 0,
+			hcip: [255, 255, 255, 255],
+			hcgateway: [255, 255, 255, 255],
+			hcmask: [255, 255, 255, 0],
+			dtb_ptr: 0,
+			hart_mask: 0,
+			timebase_freq: 0,
+		}
+	}
+}
+
+impl fmt::Debug for BootInfo {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		writeln!(f, "magic_number {:#x}", self.magic_number)?;
+		writeln!(f, "version {:#x}", self.version)?;
+		writeln!(f, "base {:#x}", self.base)?;
+		writeln!(f, "ram address {:#x}", self.ram_start)?;
+		writeln!(f, "limit {:#x}", self.limit)?;
+		writeln!(f, "tls_start {:#x}", self.tls_start)?;
+		writeln!(f, "tls_filesz {:#x}", self.tls_filesz)?;
+		writeln!(f, "tls_memsz {:#x}", self.tls_memsz)?;
+		writeln!(f, "tls_align {:#x}", self.tls_align)?;
+		writeln!(f, "image_size {:#x}", self.image_size)?;
+		writeln!(f, "current_stack_address {:#x}", self.current_stack_address)?;
+		writeln!(
+			f,
+			"current_percore_address {:#x}",
+			self.current_percore_address
+		)?;
+		writeln!(f, "host_logical_addr {:#x}", self.host_logical_addr)?;
+		writeln!(f, "boot_gtod {:#x}", self.boot_gtod)?;
+		writeln!(f, "cmdline {:#x}", self.cmdline)?;
+		writeln!(f, "cmdsize {:#x}", self.cmdsize)?;
+		writeln!(f, "cpu_freq {}", self.cpu_freq)?;
+		writeln!(f, "boot_processor {}", self.boot_processor)?;
+		writeln!(f, "cpu_online {}", self.cpu_online)?;
+		writeln!(f, "possible_cpus {}", self.possible_cpus)?;
+		writeln!(f, "current_boot_id {}", self.current_boot_id)?;
+		writeln!(f, "uartport {:#x}", self.uartport)?;
+		writeln!(f, "single_kernel {}", self.single_kernel)?;
+		writeln!(f, "uhyve {}", self.uhyve)?;
+		writeln!(f, "dtb_ptr {:x}", self.dtb_ptr)?;
+		writeln!(f, "hart_mask {:x}", self.hart_mask)?;
+		writeln!(f, "timebase_freq {}", self.timebase_freq)
+	}
+}

--- a/src/arch/riscv/head.S
+++ b/src/arch/riscv/head.S
@@ -1,0 +1,19 @@
+//Adapted from Linux (/arch/riscv/kernel/head.S)
+
+.section .text._start
+
+.global _start
+_start:
+    j _rust_start
+    .word 0
+    .balign 8
+    .dword 0x200000 //Image load offset(2MB) from start of RAM
+    .dword kernel_end - 0x80200000 //Effective size of kernel image
+	.dword 1 << 0 // header flags
+	.word (0 << 16 | 2) //version
+	.word 0
+	.dword 0
+	.ascii "RISCV\0\0\0" // magic1
+	.balign 4
+	.ascii "RSC\x05" // magic2
+    .word 0

--- a/src/arch/riscv/irq.rs
+++ b/src/arch/riscv/irq.rs
@@ -1,0 +1,69 @@
+use riscv::register::*;
+use trapframe::TrapFrame;
+
+/// Init Interrupts
+pub fn install() {
+	unsafe {
+		trapframe::init();
+	}
+}
+
+/// Enable Interrupts
+#[inline]
+pub fn enable() {
+	unsafe {
+		sstatus::set_sie();
+	}
+}
+
+/// Disable Interrupts
+#[inline]
+pub fn disable() {
+	unsafe { sstatus::clear_sie() };
+}
+
+/// Disable IRQs (nested)
+///
+/// Disable IRQs when unsure if IRQs were enabled at all.
+/// This function together with nested_enable can be used
+/// in situations when interrupts shouldn't be activated if they
+/// were not activated before calling this function.
+#[inline]
+pub fn nested_disable() -> bool {
+	let was_enabled = sstatus::read().sie();
+
+	disable();
+	was_enabled
+}
+
+/// Enable IRQs (nested)
+///
+/// Can be used in conjunction with nested_disable() to only enable
+/// interrupts again if they were enabled before.
+#[inline]
+pub fn nested_enable(was_enabled: bool) {
+	if was_enabled {
+		enable();
+	}
+}
+
+//Derived from rCore: https://github.com/rcore-os/rCore
+/// Dispatch and handle interrupt.
+///
+/// This function is called from `trap.S` which is in the trapframe crate.
+#[no_mangle]
+pub extern "C" fn trap_handler(tf: &mut TrapFrame) {
+	let scause = scause::read();
+	let stval = stval::read();
+	//trace!("Interrupt @ CPU{}: {:?} ", super::cpu::id(), scause.cause());
+	loaderlog!("Interrupt: {:?} ", scause.cause());
+	match scause.cause() {
+		// The trap occurred before the kernel sets stvec => panic!
+		_ => panic!(
+			"unhandled trap {:?}, stval: {:x} tf {:#x?}",
+			scause.cause(),
+			stval,
+			tf
+		),
+	}
+}

--- a/src/arch/riscv/link.ld
+++ b/src/arch/riscv/link.ld
@@ -1,0 +1,38 @@
+/* OUTPUT_FORMAT("elf64-x86-64")
+OUTPUT_ARCH("i386:x86-64") */
+ENTRY(_start)
+phys = 0x0000000080200000;
+
+SECTIONS
+{
+  kernel_start = phys;
+  .text phys : AT(ADDR(.text)) {
+    *(.text._start)
+    *(.text.*)
+  }
+  .rodata ALIGN(4096) : AT(ADDR(.rodata)) {
+    *(.rodata)
+    *(.rodata.*)
+  }
+  .data ALIGN(4096) : AT(ADDR(.data)) {
+    *(.data)
+    *(.data.*)
+  }
+  .bss ALIGN(4096) : AT(ADDR(.bss)) {
+    bss_start = .;
+    *(.bss)
+    *(.bss.*)
+  }
+  .sbss ALIGN(4096) : AT(ADDR(.sbss)) {
+    *(.sbss)
+    *(.sbss.*)
+  }
+  bss_end = .;
+  . = ALIGN(4096);
+  __boot_core_stack_start = .;         /*   ^             */
+                                       /*   | stack       */
+  . += 512K;                           /*   | growth      */
+                                       /*   | direction   */
+  __boot_core_stack_end_exclusive = .; /*   |             */
+  kernel_end = .;
+}

--- a/src/arch/riscv/mod.rs
+++ b/src/arch/riscv/mod.rs
@@ -1,0 +1,218 @@
+pub mod addr;
+pub mod bootinfo;
+pub mod irq;
+pub mod paging;
+pub mod physicalmem;
+pub mod serial;
+pub mod stack;
+
+pub use self::bootinfo::*;
+use crate::arch::paging::*;
+use crate::arch::riscv::serial::SerialPort;
+use crate::arch::stack::BOOT_STACK;
+use core::arch::{asm, global_asm};
+use core::slice;
+use fdt::Fdt;
+use goblin::elf;
+
+global_asm!(include_str!("head.S"));
+
+// extern "C" {
+// 	static kernel_end: u8;
+// }
+
+// CONSTANTS
+pub const ELF_ARCH: u16 = elf::header::EM_RISCV;
+
+pub const KERNEL_STACK_SIZE: usize = 32_768;
+// const SERIAL_PORT_ADDRESS: u16 = 0x3F8;
+// const SERIAL_PORT_BAUDRATE: u32 = 115200;
+
+// VARIABLES
+static COM1: SerialPort = SerialPort::new();
+pub static mut BOOT_INFO: BootInfo = BootInfo::new();
+static mut DTB_PTR: usize = 0x82200000; // Address is a placeholder
+static mut DTB_LENGTH: usize = 0;
+static mut INITIAL_HART_ID: usize = usize::MAX;
+static mut MEM_SIZE: u64 = 0;
+static mut MEM_BASE: u64 = 0;
+static mut TIMEBASE_FREQ: u64 = 0;
+static mut INITRD_START: u64 = 0;
+static mut INITRD_END: u64 = 0;
+
+static mut CMDLINE: u64 = 0;
+static mut CMDSIZE: u64 = 0;
+
+//Each set bit indicates an available hart
+static mut HART_MASK: u64 = 0;
+
+// FUNCTIONS
+pub fn message_output_init() {
+	COM1.init();
+}
+
+pub fn output_message_byte(byte: u8) {
+	COM1.write_byte(byte);
+}
+
+pub unsafe fn find_kernel() -> &'static [u8] {
+	loaderlog!("DTB_PTR: {:x}", DTB_PTR);
+	loaderlog!("INITIAL_HART_ID: {}", INITIAL_HART_ID);
+	let dtb = Fdt::from_ptr(DTB_PTR as *const u8).expect("DTB is invalid");
+	DTB_LENGTH = dtb.total_size();
+	loaderlog!("DTB length: {}", DTB_LENGTH);
+
+	// Load kernel into first memory region
+	let mem_region = dtb
+		.memory()
+		.regions()
+		.next()
+		.expect("Memory node missing or invalid");
+	MEM_BASE = mem_region.starting_address as u64;
+	MEM_SIZE = mem_region.size.unwrap() as u64;
+
+	// Get initrd address and size
+	let chosen_node = dtb
+		.find_node("/chosen")
+		.expect("Chosen node missing or invalid");
+	INITRD_START = chosen_node
+		.property("linux,initrd-start")
+		.expect("linux,initrd-start node not found in /chosen")
+		.as_usize()
+		.unwrap() as u64;
+	INITRD_END = chosen_node
+		.property("linux,initrd-end")
+		.expect("linux,initrd-end node not found in /chosen")
+		.as_usize()
+		.unwrap() as u64;
+
+	// Get command line
+	if let Some(bootargs) = dtb.chosen().bootargs() {
+		CMDSIZE = bootargs.len() as u64;
+		CMDLINE = bootargs.as_ptr() as u64;
+	}
+
+	// Get timebase-freq
+	let cpus_node = dtb
+		.find_node("/cpus")
+		.expect("cpus node missing or invalid");
+	TIMEBASE_FREQ = cpus_node
+		.property("timebase-frequency")
+		.expect("timebase-frequency node not found in /cpus")
+		.as_usize()
+		.unwrap() as u64;
+
+	// Init HART_MASK
+	for cpu in dtb.cpus() {
+		let id = cpu.ids().first();
+		let hart_id = cpu.property("reg").unwrap().as_usize().unwrap();
+		let status = cpu.property("status").unwrap().as_str().unwrap();
+
+		if status != "disabled\u{0}" {
+			HART_MASK |= 1 << hart_id;
+		}
+
+		loaderlog!("CPU ID: {}, HART_ID: {}, STATUS: {}", id, hart_id, status);
+	}
+
+	loaderlog!(
+		"mem_base: {:x}, mem_size: {:x}, timebase-freq: {}",
+		MEM_BASE,
+		MEM_SIZE,
+		TIMEBASE_FREQ
+	);
+
+	loaderlog!("Found initrd: [0x{:x} - 0x{:x}]", INITRD_START, INITRD_END);
+
+	slice::from_raw_parts(
+		INITRD_START as *const u8,
+		(INITRD_END - INITRD_START) as usize,
+	)
+}
+
+pub unsafe fn boot_kernel(
+	_elf_address: Option<u64>,
+	address: u64, // Physical address
+	mem_size: u64,
+	entry_point: u64,
+) -> ! {
+	// Supply the parameters to the HermitCore application.
+	BOOT_INFO.base = address;
+	BOOT_INFO.image_size = mem_size;
+	BOOT_INFO.current_stack_address = &BOOT_STACK as *const _ as u64;
+
+	BOOT_INFO.ram_start = MEM_BASE;
+	BOOT_INFO.limit = MEM_SIZE;
+	BOOT_INFO.timebase_freq = TIMEBASE_FREQ;
+	BOOT_INFO.dtb_ptr = DTB_PTR as u64;
+	BOOT_INFO.hart_mask = HART_MASK;
+
+	BOOT_INFO.cmdline = CMDLINE;
+	BOOT_INFO.cmdsize = CMDSIZE;
+
+	loaderlog!("BootInfo located at 0x{:x}", &BOOT_INFO as *const _ as u64);
+	loaderlog!("Use stack address 0x{:x}", BOOT_INFO.current_stack_address);
+
+	//Jump to the kernel entry point
+	loaderlog!(
+		"Jumping to HermitCore Application Entry Point at 0x{:x}",
+		entry_point
+	);
+
+	loaderlog!("BOOT_INFO: {:?}", BOOT_INFO);
+
+	irq::install();
+
+	let func: extern "C" fn(hart_id: usize, boot_info: &'static mut BootInfo) -> ! =
+		core::mem::transmute(entry_point);
+
+	func(INITIAL_HART_ID, &mut BOOT_INFO);
+}
+
+pub unsafe fn get_memory(memory_size: u64) -> u64 {
+	// TODO: Fix this
+
+	let mut start_address;
+	if DTB_PTR < INITRD_START as usize {
+		loaderlog!("DTB is located before application");
+		start_address = align_up!(DTB_PTR + DTB_LENGTH as usize, LargePageSize::SIZE);
+		if start_address + memory_size as usize >= INITRD_START as usize {
+			start_address = align_up!(INITRD_END as usize, LargePageSize::SIZE);
+			loaderlog!("Loading kernel after initrd");
+		} else {
+			loaderlog!("Loading kernel before initrd");
+		}
+	} else {
+		loaderlog!("DTB is located after application");
+		start_address = align_up!(INITRD_END as usize, LargePageSize::SIZE);
+		if start_address + memory_size as usize >= DTB_PTR {
+			start_address = align_up!(DTB_PTR + DTB_LENGTH as usize, LargePageSize::SIZE);
+			loaderlog!("Loading kernel after dtb");
+		} else {
+			loaderlog!("Loading kernel before dtb");
+		}
+	}
+
+	physicalmem::init(start_address);
+	physicalmem::allocate(align_up!(memory_size as usize, LargePageSize::SIZE)) as u64
+}
+
+#[no_mangle]
+#[naked]
+pub extern "C" fn _rust_start() -> ! {
+	unsafe {
+		asm!(
+			// Initialize sp
+			"sd a1, {dtb_ptr} ,t0",
+			"sd a0, {hart_id} ,t0",
+			"la	sp, __boot_core_stack_end_exclusive",
+
+			// jump to start
+			"j loader_main",
+
+			dtb_ptr = sym DTB_PTR,
+			hart_id = sym INITIAL_HART_ID,
+			options(noreturn)
+		)
+	}
+}

--- a/src/arch/riscv/paging.rs
+++ b/src/arch/riscv/paging.rs
@@ -1,0 +1,35 @@
+/// A generic interface to support all possible page sizes.
+///
+/// This is defined as a subtrait of Copy to enable #[derive(Clone, Copy)] for Page.
+/// Currently, deriving implementations for these traits only works if all dependent types implement it as well.
+pub trait PageSize: Copy {
+	/// The page size in bytes.
+	const SIZE: usize;
+
+	/// The page table level at which a page of this size is mapped
+	const MAP_LEVEL: usize;
+}
+
+/// A 4 KiB page mapped in the L3Table.
+#[derive(Clone, Copy)]
+pub enum BasePageSize {}
+impl PageSize for BasePageSize {
+	const SIZE: usize = 4096;
+	const MAP_LEVEL: usize = 0;
+}
+
+/// A 2 MiB page mapped in the L2Table.
+#[derive(Clone, Copy)]
+pub enum LargePageSize {}
+impl PageSize for LargePageSize {
+	const SIZE: usize = 2 * 1024 * 1024;
+	const MAP_LEVEL: usize = 1;
+}
+
+/// A 1 GiB page mapped in the L1Table.
+#[derive(Clone, Copy)]
+pub enum HugePageSize {}
+impl PageSize for HugePageSize {
+	const SIZE: usize = 1024 * 1024 * 1024;
+	const MAP_LEVEL: usize = 2;
+}

--- a/src/arch/riscv/physicalmem.rs
+++ b/src/arch/riscv/physicalmem.rs
@@ -1,0 +1,27 @@
+use crate::arch::paging::{BasePageSize, PageSize};
+
+static mut CURRENT_ADDRESS: usize = 0;
+
+pub fn init(address: usize) {
+	unsafe {
+		CURRENT_ADDRESS = address;
+	}
+}
+
+pub fn allocate(size: usize) -> usize {
+	assert!(size > 0);
+	assert_eq!(
+		size % BasePageSize::SIZE,
+		0,
+		"Size 0x{:x} is a multiple of 0x{:x}",
+		size,
+		BasePageSize::SIZE
+	);
+
+	unsafe {
+		assert!(CURRENT_ADDRESS > 0, "Trying to allocate physical memory before the Physical Memory Manager has been initialized");
+		let address = CURRENT_ADDRESS;
+		CURRENT_ADDRESS += size;
+		address
+	}
+}

--- a/src/arch/riscv/serial.rs
+++ b/src/arch/riscv/serial.rs
@@ -1,0 +1,31 @@
+use core::arch::asm;
+
+pub struct SerialPort {}
+
+impl SerialPort {
+	pub const fn new() -> Self {
+		Self {}
+	}
+
+	fn sbi_putchar(byte: u8) {
+		unsafe {
+			asm!(
+				"li a7, 0x01",
+				"ecall",
+				in("a0") byte,
+				lateout("a7") _
+			);
+		}
+	}
+
+	pub fn write_byte(&self, byte: u8) {
+		// LF newline characters need to be extended to CRLF over a real serial port.
+		if byte == b'\n' {
+			SerialPort::sbi_putchar(b'\r');
+		}
+
+		SerialPort::sbi_putchar(byte);
+	}
+
+	pub fn init(&self) {}
+}

--- a/src/arch/riscv/stack.rs
+++ b/src/arch/riscv/stack.rs
@@ -1,0 +1,41 @@
+//! Abstractions for Stacks
+
+use crate::arch::riscv::KERNEL_STACK_SIZE;
+use core::fmt::{self, Debug};
+
+/// A stack of [`STACK_SIZE`], which grows downwards.
+#[derive(Copy, Clone)]
+#[repr(align(0x100000))]
+#[repr(C)]
+pub struct Stack {
+	buffer: [u8; KERNEL_STACK_SIZE],
+}
+
+impl Stack {
+	pub const fn new() -> Stack {
+		Stack {
+			buffer: [0; KERNEL_STACK_SIZE],
+		}
+	}
+
+	pub fn top(&self) -> usize {
+		(&(self.buffer[KERNEL_STACK_SIZE - 16]) as *const _) as usize
+	}
+
+	pub fn bottom(&self) -> usize {
+		(&(self.buffer[0]) as *const _) as usize
+	}
+}
+
+impl Debug for Stack {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("Stack")
+			.field("top", &self.top())
+			.field("bottom", &self.bottom())
+			.finish()
+	}
+}
+
+/// A statically allocated boot stack, which we can safely switch to directly
+/// after boot.
+pub static mut BOOT_STACK: Stack = Stack::new();

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -152,7 +152,7 @@ pub unsafe fn load_kernel(elf: &Elf<'_>, elf_start: u64, mem_size: u64) -> (Opti
 	// relocate entries (strings, copy-data, etc.) with an addend
 	for rela in &elf.dynrelas {
 		match rela.r_type {
-			reloc::R_X86_64_RELATIVE | reloc::R_AARCH64_RELATIVE => {
+			reloc::R_X86_64_RELATIVE | reloc::R_AARCH64_RELATIVE | reloc::R_RISCV_RELATIVE => {
 				let offset = (address + rela.r_offset) as *mut u64;
 				*offset = (address as i64 + rela.r_addend.unwrap_or(0))
 					.try_into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![feature(alloc_error_handler)]
 #![cfg_attr(target_arch = "aarch64", feature(asm_const))]
+#![cfg_attr(target_arch = "riscv64", feature(naked_functions))]
+#![cfg_attr(target_arch = "riscv64", feature(asm_sym))]
 #![allow(incomplete_features)]
 #![feature(specialization)]
 #![no_std]


### PR DESCRIPTION
Closes https://github.com/hermitcore/rusty-loader/pull/11.

The rusty-loader can be build with cargo:
`cargo build --target riscv64imac-unknown-none-elf`

Usage with QEMU is similar to the x86 version:
The loader is passed via `-kernel` and the application via `-initrd`.

Example:
`qemu-system-riscv64 -cpu rv64 -machine sifive_u -nographic -m 1024 -smp 5 -kernel rusty-loader -initrd hello_world`