### PR TITLE
Rework kernel.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,12 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "cortex-a"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,7 +62,6 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c955ab4e0ad8c843ea653a3d143048b87490d9be56bd7132a435c2407846ac8f"
 dependencies = [
- "log",
  "plain",
  "scroll",
 ]
@@ -78,15 +71,6 @@ name = "llvm-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955be5d0ca0465caf127165acb47964f911e2bc26073e865deb8be7189302faf"
-
-[[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "multiboot"
@@ -116,24 +100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
 name = "raw-cpuid"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +119,7 @@ dependencies = [
  "goblin",
  "multiboot",
  "nasm-rs",
+ "plain",
  "static-alloc",
  "x86",
 ]
@@ -162,20 +129,6 @@ name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "static-alloc"
@@ -187,27 +140,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.93"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "tock-registers"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee8fba06c1f4d0b396ef61a54530bb6b28f0dc61c38bc8bc5a5a48161e6282e"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "x86"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "align-data"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1926655ba000b19e21f0402be09a1d52d318c8a8a68622870bfb7af2a71315cd"
+
+[[package]]
 name = "alloc-traits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +147,7 @@ name = "rusty-loader"
 version = "0.2.6"
 dependencies = [
  "aarch64",
+ "align-data",
  "bitflags",
  "cc",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ x86 = { version = "0.48", default-features = false }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64 = "0.0.7"
+align-data = "0.1"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-goblin = { version = "0.5", default-features = false, features = ["elf64", "elf32", "endian_fd"] }
+goblin = { version = "0.5", default-features = false, features = ["elf64"] }
+plain = "0.2"
 static-alloc = "0.2"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -19,6 +19,7 @@ extern "C" {
 }
 
 pub const ELF_ARCH: u16 = goblin::elf::header::EM_AARCH64;
+pub const R_RELATIVE: u32 = goblin::elf::reloc::R_AARCH64_RELATIVE;
 
 /// start address of the RAM at Qemu's virt emulation
 const RAM_START: u64 = 0x40000000;

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -52,7 +52,7 @@ pub unsafe fn get_memory(_memory_size: u64) -> u64 {
 }
 
 pub fn find_kernel() -> &'static [u8] {
-	include_bytes!(env!("HERMIT_APP"))
+	align_data::include_aligned!(goblin::elf64::header::Header, env!("HERMIT_APP"))
 }
 
 pub unsafe fn boot_kernel(

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -7,7 +7,6 @@ pub use crate::arch::bootinfo::*;
 use crate::arch::paging::*;
 use crate::arch::serial::SerialPort;
 use core::arch::asm;
-use goblin::elf;
 
 extern "C" {
 	static kernel_end: u8;
@@ -19,7 +18,7 @@ extern "C" {
 	static mut L0mib_pgtable: u64;
 }
 
-pub const ELF_ARCH: u16 = elf::header::EM_AARCH64;
+pub const ELF_ARCH: u16 = goblin::elf::header::EM_AARCH64;
 
 /// start address of the RAM at Qemu's virt emulation
 const RAM_START: u64 = 0x40000000;

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -8,7 +8,6 @@ use crate::arch::x86_64::paging::{BasePageSize, LargePageSize, PageSize, PageTab
 use crate::arch::x86_64::serial::SerialPort;
 use core::ptr::{copy, write_bytes};
 use core::{cmp, mem, slice};
-use goblin::elf;
 use multiboot::information::{MemoryManagement, Multiboot, PAddr};
 
 extern "C" {
@@ -17,7 +16,7 @@ extern "C" {
 }
 
 // CONSTANTS
-pub const ELF_ARCH: u16 = elf::header::EM_X86_64;
+pub const ELF_ARCH: u16 = goblin::elf::header::EM_X86_64;
 
 const KERNEL_STACK_SIZE: u64 = 32_768;
 const SERIAL_PORT_ADDRESS: u16 = 0x3F8;

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -17,6 +17,7 @@ extern "C" {
 
 // CONSTANTS
 pub const ELF_ARCH: u16 = goblin::elf::header::EM_X86_64;
+pub const R_RELATIVE: u32 = goblin::elf::reloc::R_X86_64_RELATIVE;
 
 const KERNEL_STACK_SIZE: u64 = 32_768;
 const SERIAL_PORT_ADDRESS: u16 = 0x3F8;

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -53,12 +53,6 @@ impl<'a> Object<'a> {
 				data_encoding,
 				"kernel object is not little endian"
 			);
-			let os_abi = header.e_ident[header::EI_OSABI];
-			assert_eq!(
-				header::ELFOSABI_STANDALONE,
-				os_abi,
-				"kernel is not a hermit application"
-			);
 
 			assert!(
 				matches!(header.e_type, header::ET_DYN | header::ET_EXEC),

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,172 +1,248 @@
-use crate::arch::{self, get_memory, BOOT_INFO};
-use core::ptr::{copy_nonoverlapping, write_bytes};
-use goblin::{
-	container::{Container, Ctx, Endian},
-	elf::{header, program_header, reloc, Dynamic, Elf, Header, ProgramHeader, RelocSection},
-	error::{Error as GoblinError, Result as GoblinResult},
+//! Parsing and loading kernel objects from ELF files.
+#![deny(unsafe_code)]
+
+use crate::arch::{self, BootInfo};
+
+use core::mem::{self, MaybeUninit};
+
+use goblin::elf64::{
+	dynamic::{self, Dyn, DynamicInfo},
+	header::{self, Header},
+	program_header::{self, ProgramHeader},
+	reloc::{self, Rela},
 };
+use plain::Plain;
 
-fn parse_ctx(header: &Header) -> GoblinResult<Ctx> {
-	let is_lsb = header.e_ident[header::EI_DATA] == header::ELFDATA2LSB;
-	let endianness = Endian::from(is_lsb);
-	let class = header.e_ident[header::EI_CLASS];
-	if class != header::ELFCLASS64 && class != header::ELFCLASS32 {
-		return Err(GoblinError::Malformed(format!(
-			"Unknown values in ELF ident header: class: {} endianness: {}",
-			class,
-			header.e_ident[header::EI_DATA]
-		)));
-	}
-	let is_64 = class == header::ELFCLASS64;
-	let container = if is_64 {
-		Container::Big
-	} else {
-		Container::Little
-	};
-	let ctx = Ctx::new(container, endianness);
+/// A parsed kernel object ready for loading.
+pub struct Object<'a> {
+	/// The raw bytes of the parsed ELF file.
+	elf: &'a [u8],
 
-	Ok(ctx)
+	/// The ELF file header at the beginning of [`Self::elf`].
+	header: &'a Header,
+
+	/// The kernel's program headers.
+	///
+	/// Loadable program segments will be copied for execution.
+	///
+	/// The thread-local storage segment will be used for creating [`TlsInfo`] for the kernel.
+	phs: &'a [ProgramHeader],
+
+	/// Relocations with an explicit addend.
+	relas: &'a [Rela],
 }
 
-pub fn parse(bytes: &[u8]) -> GoblinResult<Elf<'_>> {
-	let header = Elf::parse_header(bytes)?;
-	let mut elf = Elf::lazy_parse(header)?;
-	let ctx = parse_ctx(&header)?;
+impl<'a> Object<'a> {
+	/// Parses raw bytes of an ELF file into a loadable kernel object.
+	pub fn parse(elf: &[u8]) -> Object<'_> {
+		{
+			let range = elf.as_ptr_range();
+			let len = elf.len();
+			loaderlog!("Parsing kernel from ELF at {range:?} ({len} B)");
+		}
 
-	elf.program_headers =
-		ProgramHeader::parse(bytes, header.e_phoff as usize, header.e_phnum as usize, ctx)?;
+		let header = plain::from_bytes::<Header>(elf).unwrap();
 
-	elf.dynamic = Dynamic::parse(bytes, &elf.program_headers, ctx)?;
-	if let Some(dynamic) = &elf.dynamic {
-		let dyn_info = &dynamic.info;
-		elf.dynrelas = RelocSection::parse(bytes, dyn_info.rela, dyn_info.relasz, true, ctx)?;
-	}
+		// General compatibility checks
+		{
+			let class = header.e_ident[header::EI_CLASS];
+			assert_eq!(header::ELFCLASS64, class, "kernel ist not a 64-bit object");
+			let data_encoding = header.e_ident[header::EI_DATA];
+			assert_eq!(
+				header::ELFDATA2LSB,
+				data_encoding,
+				"kernel object is not little endian"
+			);
+			let os_abi = header.e_ident[header::EI_OSABI];
+			assert_eq!(
+				header::ELFOSABI_STANDALONE,
+				os_abi,
+				"kernel is not a hermit application"
+			);
 
-	Ok(elf)
-}
+			assert!(
+				matches!(header.e_type, header::ET_DYN | header::ET_EXEC),
+				"kernel has unsupported ELF type"
+			);
 
-pub fn check_kernel_elf_file(elf: &Elf<'_>) -> u64 {
-	if !elf.libraries.is_empty() {
-		panic!(
-			"Error: file depends on following libraries: {:?}",
-			elf.libraries
+			assert_eq!(
+				arch::ELF_ARCH,
+				header.e_machine,
+				"kernel is not compiled for the correct architecture"
+			);
+		}
+
+		let phs = {
+			let start = header.e_phoff as usize;
+			let len = header.e_phnum as usize;
+			ProgramHeader::slice_from_bytes_len(&elf[start..], len).unwrap()
+		};
+
+		let dyns = phs
+			.iter()
+			.find(|program_header| program_header.p_type == program_header::PT_DYNAMIC)
+			.map(|ph| {
+				let start = ph.p_offset as usize;
+				let len = (ph.p_filesz as usize) / dynamic::SIZEOF_DYN;
+				Dyn::slice_from_bytes_len(&elf[start..], len).unwrap()
+			})
+			.unwrap_or_default();
+
+		assert!(
+			!dyns.iter().any(|d| d.d_tag == dynamic::DT_NEEDED),
+			"kernel was linked against dynamic libraries"
 		);
-	}
 
-	// Verify that this module is a HermitCore ELF executable.
-	assert!(elf.header.e_machine == arch::ELF_ARCH);
-	loaderlog!("This is a supported HermitCore Application");
+		let dynamic_info = DynamicInfo::new(dyns, phs);
+		assert_eq!(0, dynamic_info.relcount);
 
-	// Get all necessary information about the ELF executable.
-	let mut file_size: u64 = 0;
-	let mut mem_size: u64 = 0;
-	let mut start_addr: u64 = u64::MAX;
+		let relas = {
+			let start = dynamic_info.rela;
+			let len = dynamic_info.relacount;
+			Rela::slice_from_bytes_len(&elf[start..], len).unwrap()
+		};
 
-	for program_header in &elf.program_headers {
-		if program_header.p_type == program_header::PT_LOAD {
-			if start_addr == u64::MAX {
-				start_addr = program_header.p_vaddr;
-			}
+		assert!(relas
+			.iter()
+			.all(|rela| reloc::r_type(rela.r_info) == arch::R_RELATIVE));
 
-			file_size += program_header.p_filesz;
-			mem_size = program_header.p_vaddr + program_header.p_memsz - start_addr;
+		Object {
+			elf,
+			header,
+			phs,
+			relas,
 		}
 	}
 
-	// Verify the information.
-	assert!(file_size > 0);
-	assert!(mem_size > 0);
-	loaderlog!("Found entry point: {:#x}", elf.entry);
-	loaderlog!("File Size: {} Bytes", file_size);
-	loaderlog!("Mem Size:  {} Bytes", mem_size);
+	/// Required memory size for loading.
+	///
+	/// Returns the minimum size of a block of memory for successfully loading the object.
+	pub fn mem_size(&self) -> usize {
+		let first_ph = self
+			.phs
+			.iter()
+			.find(|ph| ph.p_type == program_header::PT_LOAD)
+			.unwrap();
+		let start_addr = first_ph.p_vaddr;
 
-	mem_size
+		let last_ph = self
+			.phs
+			.iter()
+			.rev()
+			.find(|ph| ph.p_type == program_header::PT_LOAD)
+			.unwrap();
+		let end_addr = last_ph.p_vaddr + last_ph.p_memsz;
+
+		let mem_size = end_addr - start_addr;
+		mem_size.try_into().unwrap()
+	}
+
+	/// Loads the kernel into the provided memory.
+	pub fn load_kernel(&self, memory: &mut [MaybeUninit<u8>]) -> LoadInfo {
+		loaderlog!("Loading kernel to {memory:p}");
+
+		assert!(memory.len() >= self.mem_size());
+
+		let load_start_addr = self
+			.phs
+			.iter()
+			.find(|ph| ph.p_type == program_header::PT_LOAD)
+			.unwrap()
+			.p_vaddr;
+
+		// Load program segments
+		// Contains TLS initialization image
+		self.phs
+			.iter()
+			.filter(|ph| ph.p_type == program_header::PT_LOAD)
+			.for_each(|ph| {
+				let ph_memory = {
+					let mem_start = (ph.p_vaddr - load_start_addr) as usize;
+					let mem_len = ph.p_memsz as usize;
+					&mut memory[mem_start..][..mem_len]
+				};
+				let file_len = ph.p_filesz as usize;
+				let ph_file = &self.elf[ph.p_offset as usize..][..file_len];
+				MaybeUninit::write_slice(&mut ph_memory[..file_len], ph_file);
+				for byte in &mut ph_memory[file_len..] {
+					byte.write(0);
+				}
+			});
+
+		// Perform relocations
+		self.relas.iter().for_each(|rela| {
+			let kernel_addr = memory.as_ptr() as i64;
+			match reloc::r_type(rela.r_info) {
+				arch::R_RELATIVE => {
+					let relocated = kernel_addr + rela.r_addend;
+					MaybeUninit::write_slice(
+						&mut memory[rela.r_offset as usize..][..mem::size_of_val(&relocated)],
+						&relocated.to_ne_bytes(),
+					);
+				}
+				_ => unreachable!(),
+			}
+		});
+
+		let tls_info = self
+			.phs
+			.iter()
+			.find(|ph| ph.p_type == program_header::PT_TLS)
+			.map(|ph| TlsInfo::new(self.header, ph, memory.as_ptr() as u64));
+
+		let entry_point = {
+			let mut entry_point = self.header.e_entry;
+			if self.header.e_type == header::ET_DYN {
+				entry_point += memory.as_ptr() as u64;
+			}
+			entry_point
+		};
+
+		let elf_location = (self.header.e_type == header::ET_EXEC).then_some(load_start_addr);
+
+		LoadInfo {
+			elf_location,
+			entry_point,
+			tls_info,
+		}
+	}
 }
 
-pub unsafe fn load_kernel(elf: &Elf<'_>, elf_start: u64, mem_size: u64) -> (Option<u64>, u64, u64) {
-	loaderlog!("start {:#x}, size {:#x}", elf_start, mem_size);
-	if !elf.libraries.is_empty() {
-		panic!(
-			"Error: file depends on following libraries: {:?}",
-			elf.libraries
-		);
-	}
+pub struct LoadInfo {
+	pub elf_location: Option<u64>,
+	pub entry_point: u64,
+	pub tls_info: Option<TlsInfo>,
+}
 
-	// Verify that this module is a HermitCore ELF executable.
-	assert!(elf.header.e_machine == arch::ELF_ARCH);
+pub struct TlsInfo {
+	start: u64,
+	filesz: u64,
+	memsz: u64,
+	align: u64,
+}
 
-	if elf.header.e_ident[7] != 0xFF {
-		loaderlog!("Unsupported OS ABI {:#x}", elf.header.e_ident[7]);
-	}
-
-	let address = get_memory(mem_size);
-	loaderlog!("Load HermitCore Application at {:#x}", address);
-
-	let mut p_vaddr: u64 = u64::MAX;
-
-	// load application
-	for program_header in &elf.program_headers {
-		if program_header.p_type == program_header::PT_LOAD {
-			if p_vaddr == u64::MAX {
-				p_vaddr = program_header.p_vaddr;
-			}
-
-			// relative position to the kernel location
-			let pos = program_header.p_vaddr - p_vaddr;
-
-			copy_nonoverlapping(
-				(elf_start + program_header.p_offset) as *const u8,
-				(address + pos) as *mut u8,
-				program_header.p_filesz.try_into().unwrap(),
-			);
-			write_bytes(
-				(address + pos + program_header.p_filesz) as *mut u8,
-				0,
-				(program_header.p_memsz - program_header.p_filesz)
-					.try_into()
-					.unwrap(),
-			);
-		} else if program_header.p_type == program_header::PT_TLS {
-			if elf.header.e_type == header::ET_DYN {
-				BOOT_INFO.tls_start = address + program_header.p_vaddr;
-			} else {
-				BOOT_INFO.tls_start = program_header.p_vaddr;
-			}
-			BOOT_INFO.tls_filesz = program_header.p_filesz;
-			BOOT_INFO.tls_memsz = program_header.p_memsz;
-			BOOT_INFO.tls_align = program_header.p_align;
-
-			loaderlog!(
-				"Found TLS starts at {:#x} (size {} Bytes)",
-				BOOT_INFO.tls_start,
-				BOOT_INFO.tls_memsz
-			);
+impl TlsInfo {
+	fn new(header: &Header, ph: &ProgramHeader, start_addr: u64) -> Self {
+		let mut tls_start = ph.p_vaddr;
+		if header.e_type == header::ET_DYN {
+			tls_start += start_addr;
 		}
+		let tls_info = TlsInfo {
+			start: tls_start,
+			filesz: ph.p_filesz,
+			memsz: ph.p_memsz,
+			align: ph.p_align,
+		};
+		let range = tls_info.start as *const ()..(tls_info.start + tls_info.memsz) as *const ();
+		let len = tls_info.memsz;
+		loaderlog!("TLS is at {range:?} ({len} B)",);
+		tls_info
 	}
 
-	// relocate entries (strings, copy-data, etc.) without an addend
-	for rel in &elf.dynrels {
-		loaderlog!("Unsupported relocation type {}", rel.r_type);
-	}
-
-	// relocate entries (strings, copy-data, etc.) with an addend
-	for rela in &elf.dynrelas {
-		match rela.r_type {
-			reloc::R_X86_64_RELATIVE | reloc::R_AARCH64_RELATIVE => {
-				let offset = (address + rela.r_offset) as *mut u64;
-				*offset = (address as i64 + rela.r_addend.unwrap_or(0))
-					.try_into()
-					.unwrap();
-			}
-			_ => {
-				loaderlog!("Unsupported relocation type {}", rela.r_type);
-			}
-		}
-	}
-
-	if elf.header.e_type == header::ET_DYN {
-		(None, address, elf.entry + address)
-	} else {
-		(Some(p_vaddr), address, elf.entry)
+	pub fn insert_into(&self, boot_info: &mut BootInfo) {
+		boot_info.tls_start = self.start;
+		boot_info.tls_filesz = self.filesz;
+		boot_info.tls_memsz = self.memsz;
+		boot_info.tls_align = self.align;
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,10 @@
 #![cfg_attr(target_arch = "aarch64", feature(asm_const))]
 #![allow(incomplete_features)]
 #![feature(specialization)]
+#![feature(maybe_uninit_write_slice)]
 #![no_std]
 #![warn(rust_2018_idioms)]
 #![allow(clippy::missing_safety_doc)]
-
-#[macro_use]
-extern crate alloc;
 
 #[macro_use]
 pub mod macros;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,13 @@
 #[macro_use]
 extern crate rusty_loader;
 
-use rusty_loader::{arch, init_bss, kernel};
+use core::{mem::MaybeUninit, slice};
+
+use rusty_loader::{
+	arch::{self, BOOT_INFO},
+	init_bss,
+	kernel::{LoadInfo, Object},
+};
 
 extern "C" {
 	static kernel_end: u8;
@@ -27,16 +33,28 @@ pub unsafe extern "C" fn loader_main() -> ! {
 		&kernel_end as *const u8 as usize
 	);
 
-	let app = arch::find_kernel();
-	let elf = kernel::parse(app).expect("Unable to parse ELF file");
-	assert_ne!(
-		elf.entry, 0,
-		"Goblin failed to find entry point of the kernel in the Elf header"
-	);
-	let mem_size = kernel::check_kernel_elf_file(&elf);
-	let (elf_location, kernel_location, entry_point) =
-		kernel::load_kernel(&elf, app.as_ptr() as u64, mem_size);
+	let kernel = Object::parse(arch::find_kernel());
 
-	// boot kernel
-	arch::boot_kernel(elf_location, kernel_location, mem_size, entry_point)
+	let memory = {
+		let mem_size = kernel.mem_size();
+		let kernel_addr = arch::get_memory(mem_size as u64);
+		slice::from_raw_parts_mut(kernel_addr as *mut MaybeUninit<u8>, mem_size)
+	};
+
+	let LoadInfo {
+		elf_location,
+		entry_point,
+		tls_info,
+	} = kernel.load_kernel(memory);
+
+	if let Some(tls_info) = tls_info {
+		tls_info.insert_into(&mut BOOT_INFO);
+	}
+
+	arch::boot_kernel(
+		elf_location,
+		memory.as_ptr() as u64,
+		memory.len() as u64,
+		entry_point,
+	)
 }


### PR DESCRIPTION
Closes https://github.com/hermitcore/rusty-loader/issues/90.

1. Parses the kernel from the ELF file without any allocations. (I will completely remove the allocator in a future PR)
2. Parses the kernel without any use of `unsafe`.
3. Heavily reduces the amount of transitive dependencies.
4. The loader can now be built with `opt-level = 0` on x86. (I will perform this change in a future PR)