### PR TITLE
CI: Don't test aarch64 on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         arch: [x86_64, aarch64]
+        exclude:
+          # TODO: Workaround for https://github.com/hermitcore/rusty-loader/issues/99
+          - os: macos-latest
+            arch: aarch64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install QEMU, NASM (ubuntu)

--- a/bors.toml
+++ b/bors.toml
@@ -4,7 +4,6 @@ status = [
   "Integration Test (ubuntu-latest, x86_64)",
   "Integration Test (ubuntu-latest, aarch64)",
   "Integration Test (macos-latest, x86_64)",
-  "Integration Test (macos-latest, aarch64)",
   "Integration Test (windows-latest, x86_64)",
   "Integration Test (windows-latest, aarch64)",
 ]


### PR DESCRIPTION
Workaround for https://github.com/hermitcore/rusty-loader/issues/99.