### PR TITLE
Rework printing

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -1,22 +1,14 @@
-use crate::arch;
 use core::fmt;
 
-pub struct Console;
+pub struct Console(());
 
-/// A collection of methods that are required to format
-/// a message to HermitCore's console.
 impl fmt::Write for Console {
-	/// Print a single character.
-	fn write_char(&mut self, c: char) -> fmt::Result {
-		arch::output_message_byte(c as u8);
-		Ok(())
-	}
-
-	/// Print a string of characters.
 	fn write_str(&mut self, s: &str) -> fmt::Result {
-		for character in s.chars() {
-			self.write_char(character).unwrap();
+		for byte in s.bytes() {
+			crate::arch::output_message_byte(byte);
 		}
 		Ok(())
 	}
 }
+
+pub static mut CONSOLE: Console = Console(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,11 @@ pub unsafe fn init_bss() {
 	let slice = slice::from_raw_parts_mut(start_ptr, len);
 	slice.fill(MaybeUninit::new(0));
 }
+
+#[doc(hidden)]
+pub fn _print(args: ::core::fmt::Arguments<'_>) {
+	use core::fmt::Write;
+	unsafe {
+		crate::console::CONSOLE.write_fmt(args).unwrap();
+	}
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,24 +16,28 @@ macro_rules! align_up {
 /// for HermitCore.
 #[macro_export]
 macro_rules! print {
-	($($arg:tt)+) => ({
-		use core::fmt::Write;
-
-		let mut console = $crate::console::Console {};
-		console.write_fmt(format_args!($($arg)+)).unwrap();
-	});
+    ($($arg:tt)*) => {{
+        $crate::_print(::core::format_args!($($arg)*));
+    }};
 }
 
 /// Print formatted text to our console, followed by a newline.
 #[macro_export]
 macro_rules! println {
-	($($arg:tt)+) => (print!("{}\n", format_args!($($arg)+)));
+    () => {
+        $crate::print!("\n")
+    };
+    ($($arg:tt)*) => {{
+        print!("{}\n", ::core::format_args!($($arg)*))
+    }};
 }
 
 /// Print formatted loader log messages to our console, followed by a newline.
 #[macro_export]
 macro_rules! loaderlog {
-	($($arg:tt)+) => (println!("[LOADER] {}", format_args!($($arg)+)));
+    ($($arg:tt)*) => {{
+        print!("[LOADER] {}\n", ::core::format_args!($($arg)*))
+    }};
 }
 
 /// Prints and returns the value of a given expression for quick and dirty


### PR DESCRIPTION
This reworks printing.

1. Casting `char` to `u8` is incorrect for multi-byte characters. The new implementation now correctly prints emojis. :sparkling_heart: 
2. I added `_print` for not having to handle the `Console` inside the macros.
3. I aligned the macros with their updated `std` counterparts.