### PR TITLE
Revert "[REVERT] Don't enforce OSABI"

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -53,6 +53,12 @@ impl<'a> Object<'a> {
 				data_encoding,
 				"kernel object is not little endian"
 			);
+			let os_abi = header.e_ident[header::EI_OSABI];
+			assert_eq!(
+				header::ELFOSABI_STANDALONE,
+				os_abi,
+				"kernel is not a hermit application"
+			);
 
 			assert!(
 				matches!(header.e_type, header::ET_DYN | header::ET_EXEC),


### PR DESCRIPTION
This reverts commit 913135a547d833732daf789a60f6a601cab641c2.

This depends on https://github.com/hermitcore/rusty-hermit/issues/300.