### PR TITLE
Revert "Revert "[REVERT] Don't enforce OSABI""

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -54,12 +54,6 @@ impl<'a> Object<'a> {
 				data_encoding,
 				"kernel object is not little endian"
 			);
-			let os_abi = header.e_ident[header::EI_OSABI];
-			assert_eq!(
-				header::ELFOSABI_STANDALONE,
-				os_abi,
-				"kernel is not a hermit application"
-			);
 
 			assert!(
 				matches!(header.e_type, header::ET_DYN | header::ET_EXEC),


### PR DESCRIPTION
Reverts hermitcore/rusty-loader#111.

There are issues with using the latest toolchain with RustyHermit's rusty-demo, so that has to be resolved first.