### PR TITLE
Fixup: Populate BootInfo::cmd{line,size}

### DIFF
--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -249,6 +249,8 @@ pub unsafe fn boot_kernel(
 		image_size: mem_size,
 		tls_info,
 		current_stack_address,
+		cmdline,
+		cmdsize,
 		uartport: SERIAL_IO_PORT,
 		mb_info: mb_info as u64,
 		..Default::default()


### PR DESCRIPTION
As an oversight in https://github.com/hermitcore/rusty-loader/pull/123, I forgot to populate `BootInfo::cmd{line,size}`.

Closes https://github.com/hermitcore/hermit-entry/issues/3.