### PR TITLE
add `sysctl -w net.ipv4.ip_forward=1` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ The following commands establish the tap device `tap10` on Linux:
 # ip addr add 10.0.5.1/24 broadcast 10.0.5.255 dev tap10
 # ip link set dev tap10 up
 # echo 1 > /proc/sys/net/ipv4/conf/tap10/proxy_arp
+```
+
+If you want Hermit to be accessible from outside the host, you have to enable IP forwarding:
+```
 # sysctl -w net.ipv4.ip_forward=1
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following commands establish the tap device `tap10` on Linux:
 # ip addr add 10.0.5.1/24 broadcast 10.0.5.255 dev tap10
 # ip link set dev tap10 up
 # echo 1 > /proc/sys/net/ipv4/conf/tap10/proxy_arp
+# sysctl -w net.ipv4.ip_forward=1
 ```
 
 You need to enable the `tcp` feature of the kernel.


### PR DESCRIPTION
We need to also set `sysctl -w net.ipv4.ip_forward=1` so that traffic gets routed by the host from to hermit.