### PR TITLE
Migrate from deprecated license format to SPDX License Expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rusty-loader"
 version = "0.4.0"
 authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>", "Colin Finck <colin.finck@rwth-aachen.de>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
 


### PR DESCRIPTION
See
https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60