### PR TITLE
use Flattened DeviceTrees to determine the hardware specification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo xtask build --target ${{ matrix.target }}
-        env:
-          HERMIT_APP: ${{ github.workspace }}/data/${{ matrix.target }}/hello_world
       - name: Run loader (x86_64)
         if: matrix.target == 'x86_64'
         run: |
@@ -99,11 +97,10 @@ jobs:
           qemu-system-aarch64 \
             -machine virt,gic-version=max -cpu cortex-a72 -smp 1 -m 512M \
             -display none -serial stdio -semihosting \
-            -kernel target/aarch64/debug/rusty-loader
+            -kernel target/aarch64/debug/rusty-loader \
+            -device guest-loader,addr=0x48000000,initrd=data/aarch64/hello_world
       - name: Build (release)
         run: cargo xtask build --target ${{ matrix.target }} --release
-        env:
-          HERMIT_APP: ${{ github.workspace }}/data/${{ matrix.target }}/hello_world
       - name: Run loader (release, x86_64)
         if: matrix.target == 'x86_64'
         run: |
@@ -127,4 +124,5 @@ jobs:
           qemu-system-aarch64 \
             -machine virt,gic-version=max -cpu cortex-a72 -smp 1 -m 512M \
             -display none -serial stdio -semihosting \
-            -kernel target/aarch64/release/rusty-loader
+            -kernel target/aarch64/release/rusty-loader \
+            -device guest-loader,addr=0x48000000,initrd=data/aarch64/hello_world

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "fdt"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
+
+[[package]]
 name = "goblin"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +165,7 @@ version = "0.4.0"
 dependencies = [
  "align-data",
  "cc",
+ "fdt",
  "hermit-entry",
  "log",
  "multiboot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,21 +22,15 @@ checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "bit_field"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
@@ -58,9 +52,9 @@ checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
 name = "goblin"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572564d6cba7d09775202c8e7eebc4d534d5ae36578ab402fb21e182a0ac9505"
+checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
 dependencies = [
  "plain",
  "scroll",
@@ -111,9 +105,9 @@ checksum = "ce095842aee9aa3ecbda7a5d2a4df680375fd128a8596b6b56f8e497e231f483"
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "plain"
@@ -123,9 +117,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -152,27 +146,27 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rusty-loader"
 version = "0.4.0"
 dependencies = [
  "align-data",
- "byteorder",
  "cc",
  "fdt",
+ "goblin",
  "hermit-entry",
  "log",
  "multiboot",
@@ -191,9 +185,9 @@ checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -202,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "time-core",
 ]
@@ -272,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "volatile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +170,7 @@ name = "rusty-loader"
 version = "0.4.0"
 dependencies = [
  "align-data",
+ "byteorder",
  "cc",
  "fdt",
  "hermit-entry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ x86_64 = { version = "0.14", default-features = false }
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 align-data = "0.1"
 fdt = { version = "0.1.5" }
-byteorder = { version = "1", default-features = false }
+goblin = { version = "0.6", default-features = false, features = ["elf64"] }
 
 [target.'cfg(target_os = "uefi")'.dependencies]
 uefi = { version = "0.20" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ x86_64 = { version = "0.14", default-features = false }
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 align-data = "0.1"
 fdt = { version = "0.1.5" }
+byteorder = { version = "1", default-features = false }
 
 [target.'cfg(target_os = "uefi")'.dependencies]
 uefi = { version = "0.20" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ x86_64 = { version = "0.14", default-features = false }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 align-data = "0.1"
+fdt = { version = "0.1.5" }
 
 [target.'cfg(target_os = "uefi")'.dependencies]
 uefi = { version = "0.20" }

--- a/data/aarch64/hello_world
+++ b/data/aarch64/hello_world
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bfe947ed5847f9a33c61cd6aca8beafe83870acb7c8f0cb1ba2fb71bf684881e
-size 3228544
+oid sha256:b504d19c3e02cd0d4d42d7936adc44e634dfdbbcd5b1705a59fbad4e5fb3f208
+size 155160

--- a/data/aarch64/hello_world
+++ b/data/aarch64/hello_world
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1697b57079d7be4385c90e41e3149d344217e5963b74cfd2fce6e29d175214c1
-size 175672
+oid sha256:bfe947ed5847f9a33c61cd6aca8beafe83870acb7c8f0cb1ba2fb71bf684881e
+size 3228544

--- a/data/x86_64/hello_world
+++ b/data/x86_64/hello_world
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de945fe36312012702b58cd84a2595ffe9ecbca0d83b3ea7607fdfbbeb2a3066
-size 5016632
+oid sha256:79e03d298f570f3be67759ebc6a5f7ff453ff0c2f2b28916076a23b58e7c15aa
+size 1965616

--- a/src/arch/aarch64/link.ld
+++ b/src/arch/aarch64/link.ld
@@ -5,7 +5,7 @@
 OUTPUT_FORMAT("elf64-littleaarch64")
 OUTPUT_ARCH("aarch64")
 ENTRY(_start)
-phys = 0x40000000;
+phys = 0x40200000;
 
 PHDRS
 {
@@ -18,7 +18,7 @@ SECTIONS
 {
   . = phys;
   kernel_start = .;
-  .text ALIGN(4096) : AT(phys) {
+  .text : {
     KEEP(*(.text._start))
     *(.text)
     *(.text.*)
@@ -47,7 +47,7 @@ SECTIONS
    ***********************************************************************************************/
   __boot_core_stack_start = .;         /*   ^             */ 
                                        /*   | stack       */
-  . += 16K;                           /*   | growth      */
+  . += 16K;                            /*   | growth      */
                                        /*   | direction   */
   __boot_core_stack_end_exclusive = .; /*   |             */
   kernel_end = .;

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -30,6 +30,10 @@ const RAM_START: u64 = 0x40000000;
 const SERIAL_PORT_ADDRESS: u32 = 0x09000000;
 /// Default stack size of the kernel
 const KERNEL_STACK_SIZE: usize = 32_768;
+/// Qemu assumes for ELF kernel that the DTB is located at
+/// start of RAM (0x4000_0000)
+/// see <https://qemu.readthedocs.io/en/latest/system/arm/virt.html>
+const FDT: u64 = RAM_START;
 
 const PT_DEVICE: u64 = 0x707;
 const PT_PT: u64 = 0x713;
@@ -41,7 +45,28 @@ const PT_SELF: u64 = 1 << 55;
 static mut COM1: SerialPort = SerialPort::new(SERIAL_PORT_ADDRESS);
 
 pub fn message_output_init() {
-	// nothing to do
+	let fdt = unsafe {
+		core::slice::from_raw_parts(
+			FDT as *mut u8,
+			&kernel_end as *const u8 as usize - RAM_START as usize,
+		)
+	};
+	let fdt = fdt::Fdt::new(fdt).unwrap();
+
+	let uart_address: u32 = if let Some(stdout) = fdt.chosen().stdout() {
+		if let Some(pos) = stdout.name.find("@") {
+			let len = stdout.name.len();
+			u32::from_str_radix(&stdout.name[pos + 1..len], 16).unwrap_or(SERIAL_PORT_ADDRESS)
+		} else {
+			SERIAL_PORT_ADDRESS
+		}
+	} else {
+		SERIAL_PORT_ADDRESS
+	};
+
+	unsafe {
+		COM1.set_port(uart_address);
+	}
 }
 
 pub fn output_message_byte(byte: u8) {
@@ -65,6 +90,18 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 		load_info,
 		entry_point,
 	} = kernel_info;
+
+	let fdt = unsafe {
+		core::slice::from_raw_parts(
+			FDT as *mut u8,
+			&kernel_end as *const u8 as usize - RAM_START as usize,
+		)
+	};
+	let fdt = fdt::Fdt::new(fdt).unwrap();
+	info!("Detect {} CPU(s)", fdt.cpus().count());
+
+	let uart_address: u32 = unsafe { COM1.get_port() };
+	info!("Detect UART at {:#x}", uart_address);
 
 	let pgt_slice = core::slice::from_raw_parts_mut(&mut l0_pgtable as *mut u64, 512);
 	for i in pgt_slice.iter_mut() {
@@ -90,7 +127,7 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 	for i in pgt_slice.iter_mut() {
 		*i = 0;
 	}
-	pgt_slice[1] = SERIAL_PORT_ADDRESS as u64 + PT_MEM_CD;
+	pgt_slice[1] = uart_address as u64 + PT_MEM_CD;
 
 	// map kernel to KERNEL_START and stack below the kernel
 	let pgt_slice = core::slice::from_raw_parts_mut(&mut l2k_pgtable as *mut u64, 512);
@@ -132,10 +169,20 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 
 	let current_stack_address = load_info.kernel_image_addr_range.start - KERNEL_STACK_SIZE as u64;
 	pub static mut BOOT_INFO: Option<RawBootInfo> = None;
+
+	let ram_start = fdt.memory().regions().next().unwrap().starting_address as u64;
+	let ram_size = fdt
+		.memory()
+		.regions()
+		.next()
+		.unwrap()
+		.size
+		.unwrap_or(0x20000000usize) as u64;
+
 	BOOT_INFO = {
 		let boot_info = BootInfo {
 			hardware_info: HardwareInfo {
-				phys_addr_range: RAM_START..RAM_START + 0x20000000, // 512 MB
+				phys_addr_range: ram_start..ram_start + ram_size,
 				serial_port_base: SerialPortBase::new(0x1000),
 			},
 			load_info,

--- a/src/arch/aarch64/paging.rs
+++ b/src/arch/aarch64/paging.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use core::marker::PhantomData;
 
 /// Number of Offset bits of a virtual address for a 4 KiB page, which are shifted away to get its Page Frame Number (PFN).

--- a/src/arch/aarch64/serial.rs
+++ b/src/arch/aarch64/serial.rs
@@ -11,6 +11,10 @@ impl SerialPort {
 		core::ptr::write_volatile(&mut self.port_address, addr);
 	}
 
+	pub unsafe fn get_port(&self) -> u32 {
+		core::ptr::read_volatile(&self.port_address)
+	}
+
 	pub fn write_byte(&self, byte: u8) {
 		unsafe {
 			let port = core::ptr::read_volatile(&self.port_address) as *mut u8;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -151,19 +151,13 @@ impl flags::Clippy {
 		for target in [Target::X86_64] {
 			target.install()?;
 			let triple = target.triple();
-			cmd!(sh, "cargo clippy --target={triple}")
-				.env("HERMIT_APP", hermit_app(target))
-				.run()?;
+			cmd!(sh, "cargo clippy --target={triple}").run()?;
 		}
 
 		cmd!(sh, "cargo clippy --package xtask").run()?;
 
 		Ok(())
 	}
-}
-
-fn hermit_app(target: Target) -> PathBuf {
-	["data", target.name(), "hello_world"].iter().collect()
 }
 
 fn binutil(name: &str) -> Result<PathBuf> {


### PR DESCRIPTION
Qemu stores the device tree at the beginning of the RAM. Consequently, we have to move the loader to create space for the device tree. Afterwards, the device tree can be used to determine the UART address and the memory regions.