### PR TITLE
Bump uefi to 0.24, uefi-services to 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c66321e9355bcd547e25268acd230530cb17a1569ec0ed142237f3967075dcd"
+checksum = "3b63e82686b4bdb0db74f18b2abbd60a0470354fb640aa69e115598d714d0a10"
 dependencies = [
  "bitflags 2.3.1",
  "log",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73e08d8e944b7c7e90a7c8a53213bdd71ceb7b414ee664f522c1cc579888c25"
+checksum = "62642516099c6441a5f41b0da8486d5fc3515a0603b0fdaea67b31600e22082e"
 dependencies = [
  "bitflags 2.3.1",
  "ptr_meta",
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-services"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2788f4d571cf33b37838f238e732840c3ec42e899b141bcd96d2b84cf2c2e614"
+checksum = "44b32954ebbb4be5ebfde0df6699c2091f04e9f9c3762c65f3435dfb1a90a668"
 dependencies = [
  "cfg-if",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ hermit-dtb = { version = "0.1" }
 goblin = { version = "0.7", default-features = false, features = ["elf64"] }
 
 [target.'cfg(target_os = "uefi")'.dependencies]
-uefi = "0.23"
-uefi-services = "0.20"
+uefi = "0.24"
+uefi-services = "0.21"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Closes https://github.com/hermitcore/rusty-loader/pull/233, https://github.com/hermitcore/rusty-loader/pull/234.