### PR TITLE
README: Remove qemu64 CPU, add KVM & invtsc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Boot a hermit application:
 $ qemu-system-x86_64 \
     -cpu qemu64,apic,fsgsbase,fxsr,rdrand,rdtscp,xsave,xsaveopt \
     -smp 1 \
-    -m 64M \
+    -m 128M \
     -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
     -display none -serial stdio \
     -kernel <LOADER> \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Boot a hermit application:
 ```
 $ qemu-system-x86_64 \
     -cpu qemu64,apic,fsgsbase,fxsr,rdrand,rdtscp,xsave,xsaveopt \
-    -smp 1 -m 64M \
+    -smp 1 \
+    -m 64M \
     -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
     -display none -serial stdio \
     -kernel <LOADER> \
@@ -43,7 +44,9 @@ On AArch64, the base command is as follows:
 ```
 $ qemu-system-aarch64 \
                   -machine virt,gic-version=3 \
-                  -cpu cortex-a76 -smp 1 -m 512M  \
+                  -cpu cortex-a76 \
+                  -smp 1 \
+                  -m 512M  \
                   -semihosting \
                   -display none -serial stdio \
                   -kernel <LOADER> \

--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ Afterward, the loader is located at `target/<TARGET>/release/rusty-loader`.
 
 ## Running
 
-Boot a hermit application:
+### x86-64
+
+On x86-64 Linux with KVM, you can boot Hermit like this:
 
 ```
 $ qemu-system-x86_64 \
-    -cpu qemu64,apic,fsgsbase,fxsr,rdrand,rdtscp,xsave,xsaveopt \
+    -enable-kvm \
+    -cpu host \
     -smp 1 \
     -m 128M \
     -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
@@ -32,12 +35,24 @@ $ qemu-system-x86_64 \
     -initrd <APP>
 ```
 
-Arguments can be provided like this:
+#### No KVM
+
+If you want to emulate x86-64 instead of using KVM, omit `-enable-kvm` and set the CPU explicitly to a model of your choice, for example `-cpu Skylake-Client`.
+
+#### Benchmarking
+
+If you want to benchmark Hermit, make sure to enable the _invariant TSC_ (`invtsc`) feature by setting `-cpu host,migratable=no,+invtsc,enforce`.
+
+#### Providing Arguments
+
+Unikernel arguments can be provided like this:
 
 ```
 $ qemu-system-x86_64 ... \
     -append "[KERNEL_ARGS] [--] [APP_ARGS]"
 ```
+
+### AArch64
 
 On AArch64, the base command is as follows:
 


### PR DESCRIPTION
This replaces our custom `qemu64,apic,fsgsbase,fxsr,rdrand,rdtscp,xsave,xsaveopt` CPU with the host CPU and refers to using `-cpu Skylake-Client` when using emulation.

This also adds QEMU instructions useful for benchmarking.